### PR TITLE
Add logger and adjust password creation

### DIFF
--- a/src/utils/logs/logger.js
+++ b/src/utils/logs/logger.js
@@ -1,0 +1,31 @@
+const { createLogger, format, transports } = require('winston')
+require('winston-daily-rotate-file')
+const path = require('path')
+const fs = require('fs')
+
+const logDir = path.join(__dirname, '../../../logs')
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir, { recursive: true })
+}
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.printf(({ level, message, timestamp }) => {
+      return `${timestamp} [${level}] ${message}`
+    })
+  ),
+  transports: [
+    new transports.DailyRotateFile({
+      filename: path.join(logDir, 'app-%DATE%.log'),
+      datePattern: 'YYYY-MM-DD',
+      zippedArchive: false,
+      maxSize: '20m',
+      maxFiles: '14d'
+    }),
+    new transports.Console()
+  ]
+})
+
+module.exports = logger


### PR DESCRIPTION
## Summary
- implement a Winston based logger utility
- remove `|` from password special characters in `registerWithInvitation`
- add logs for invitation registration steps
- remove undefined logger call in `getLastUpdate`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c60f40068832da5080ccab5e1d1e9