### PR TITLE
Fix fileMethod scope in registerWithInvitation

### DIFF
--- a/src/controllers/api/usuarios.js
+++ b/src/controllers/api/usuarios.js
@@ -120,8 +120,8 @@ exports.getUserById = async (req, res, next) => {
 }
 
 exports.registerWithInvitation = async (req, res, next) => {
+  const fileMethod = `file: src/controllers/api/usuarios.js - method: registerWithInvitation`
   try {
-    const fileMethod = `file: src/controllers/api/usuarios.js - method: registerWithInvitation`
     const parsedData = typeof req.decryptedBody === 'string' ? JSON.parse(req.decryptedBody) : req.decryptedBody
     logger.info(`${fileMethod} | Datos recibidos: ${JSON.stringify(parsedData)}`)
     const { email, id_usuario, id_empresa, id_rol, nombre_usuario, apellido_usuario, perfil } = parsedData


### PR DESCRIPTION
## Summary
- move `fileMethod` variable outside the `try` block in `registerWithInvitation`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c66296a98832d98a6fa455d8827b7