### PR TITLE
Make legal incidents scoring dynamic

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -2358,55 +2358,60 @@ const getScoreIncidenciasLegales = async (id_certification, algoritmo_v, customU
         }
       }
     } else {
+      const getScore = await certificationService.getScoreIncidenciasLegales('NINGUNA', algoritmo_v)
       respuesta = {
-        score: '0',
+        score: getScore ? getScore.valor_algoritmo : '0',
         tipo: null,
         fecha: null,
-        caso: 'NINGUNA'
+        caso: getScore ? getScore.nombre : 'NINGUNA'
       }
       logger.info(`${fileMethod} | ${customUuid} Incidencias legales obtenidas: ${JSON.stringify(respuesta)}`)
       return respuesta
     }
 
     if (countIncMerc == 0 && !incidenciaPenal) {
+      const getScore = await certificationService.getScoreIncidenciasLegales('NINGUNA', algoritmo_v)
       respuesta = {
-        score: '0',
+        score: getScore ? getScore.valor_algoritmo : '0',
         tipo: null,
         fecha: null,
-        caso: 'NINGUNA'
+        caso: getScore ? getScore.nombre : 'NINGUNA'
       }
       logger.info(`${fileMethod} | ${customUuid} Incidencias legales obtenidas: ${JSON.stringify(respuesta)}`)
       return respuesta
     }
 
     if (incidenciaPenal) {
+      const getScore = await certificationService.getScoreIncidenciasLegales('>= 1 INCIDENCIA PENAL ( no importando el año)', algoritmo_v)
       respuesta = {
-        score: '-250',
+        score: getScore ? getScore.valor_algoritmo : '-250',
         tipo: tipo,
         fecha: fecha,
-        caso: '>= 1 INCIDENCIA PENAL ( no importando el año)'
+        caso: getScore ? getScore.nombre : '>= 1 INCIDENCIA PENAL ( no importando el año)'
       }
       logger.info(`${fileMethod} | ${customUuid} >= 1 INCIDENCIA PENAL ( no importando el año) ${JSON.stringify(respuesta)}`)
       return respuesta
     }
 
     if (_1incidenciaMercantilUnAnio) {
+      const getScore = await certificationService.getScoreIncidenciasLegales('1 INCIDENCIA MERCANTIL <= 1 AÑO', algoritmo_v)
       respuesta = {
-        score: algoritmo_v.v_alritmo == 2 ? '-40' : '-50',
+        score: getScore ? getScore.valor_algoritmo : algoritmo_v.v_alritmo == 2 ? '-40' : '-50',
         tipo: tipo,
         fecha: fecha,
-        caso: '1 INCIDENCIA MERCANTIL <= 1 AÑO'
+        caso: getScore ? getScore.nombre : '1 INCIDENCIA MERCANTIL <= 1 AÑO'
       }
       logger.info(`${fileMethod} | ${customUuid} 1 INCIDENCIA MERCANTIL <= 1 AÑO ${JSON.stringify(respuesta)}`)
       return respuesta
     }
 
     if (_2incidenciaMercantilUnAnio) {
+      const getScore = await certificationService.getScoreIncidenciasLegales('2 INCIDENCIAS MERCANTILES <= 1 AÑO', algoritmo_v)
       respuesta = {
-        score: '-200',
+        score: getScore ? getScore.valor_algoritmo : '-200',
         tipo: tipo,
         fecha: fecha,
-        caso: '2 INCIDENCIAS MERCANTILES <= 1 AÑO'
+        caso: getScore ? getScore.nombre : '2 INCIDENCIAS MERCANTILES <= 1 AÑO'
       }
       logger.info(`${fileMethod} | ${customUuid} 2 INCIDENCIAS MERCANTILES <= 1 AÑO ${JSON.stringify(respuesta)}`)
       return respuesta

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3469,6 +3469,25 @@ WHERE
     return result
   }
 
+  async getScoreIncidenciasLegales(nombre, algoritmo_v) {
+    const valor_algoritmo =
+      algoritmo_v.v_alritmo === 2
+        ? 'valor_algoritmo_v2 AS valor_algoritmo'
+        : 'valor_algoritmo'
+
+    const queryString = `
+    SELECT
+      nombre,
+      ${valor_algoritmo},
+      limite_inferior,
+      limite_superior
+    FROM cat_incidencias_legales_algoritmo
+    WHERE nombre = ${mysqlLib.escape(nombre)};
+    `
+    const { result } = await mysqlLib.query(queryString)
+    return result[0]
+  }
+
   async deudaCortoPlazo(id_certification) {
     const queryString = `
     SELECT


### PR DESCRIPTION
## Summary
- pull scores for legal incidents from `cat_incidencias_legales_algoritmo`
- create `getScoreIncidenciasLegales` service method
- use dynamic values in controller instead of hardcoded ones

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c8474cd6c832d9b96e07e4c7a5742