### PR TITLE
Use catalog for reference scores

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3503,6 +3503,35 @@ WHERE cer.certificacion_id = (
     return result[0]
   }
 
+  async getCatResultadoReferenciasProveedores() {
+    const queryString = `
+    SELECT
+      nombre,
+      valor_algoritmo,
+      valor_algoritmo_v2
+    FROM cat_resultado_referencias_proveedores_algoritmo;
+    `
+    const { result } = await mysqlLib.query(queryString)
+    return result
+  }
+
+  async getScoreResultadoReferencias(nombre, algoritmo_v) {
+    const valor_algoritmo =
+      algoritmo_v.v_alritmo === 2
+        ? 'valor_algoritmo_v2 AS valor_algoritmo'
+        : 'valor_algoritmo'
+
+    const queryString = `
+    SELECT
+      nombre,
+      ${valor_algoritmo}
+    FROM cat_resultado_referencias_proveedores_algoritmo
+    WHERE nombre = ${mysqlLib.escape(nombre)};
+    `
+    const { result } = await mysqlLib.query(queryString)
+    return result[0]
+  }
+
   async deudaCortoPlazo(id_certification) {
     const id = mysqlLib.escape(id_certification)
     const queryString = `


### PR DESCRIPTION
## Summary
- centralize reference description constants
- fetch reference result scores from catalog table
- expose new service methods for comercial reference results

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_684c92b4712c832da69f0cc16b5d9615