### PR TITLE
Add ranges info to email report

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4210,7 +4210,10 @@ const getAlgoritmoResult = async (req, res, next) => {
     logger.info(`${fileMethod} | ${customUuid} C48: Monto de linea sugerida  ${c48}`)
     scores.c48 = c48
 
-    const emailReporteResumenEmail = sendEmailNodeMailer({ info_email: scores })
+    const emailReporteResumenEmail = sendEmailNodeMailer({ info_email: {
+      scores,
+      rangos: reporteCredito
+    } })
     logger.info(`${fileMethod} | ${customUuid} | Resumen de reporte de credito ejecutado: ${JSON.stringify(scores)}`)
 
     reporteCredito.monto_solicitado = monto_solicitado


### PR DESCRIPTION
## Summary
- include rango data from reporteCredito when emailing scores

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c9c2ddc18832d8681442c4b5be72f