### PR TITLE
Add method for algorithm ranges in certification email

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4210,10 +4210,14 @@ const getAlgoritmoResult = async (req, res, next) => {
     logger.info(`${fileMethod} | ${customUuid} C48: Monto de linea sugerida  ${c48}`)
     scores.c48 = c48
 
-    const emailReporteResumenEmail = sendEmailNodeMailer({ info_email: {
-      scores,
-      rangos: reporteCredito
-    } })
+    const rangosBD = await certificationService.getAllAlgorithmRanges()
+    const emailReporteResumenEmail = sendEmailNodeMailer({
+      info_email: {
+        scores,
+        rangos: reporteCredito
+      },
+      rangos_bd: rangosBD
+    })
     logger.info(`${fileMethod} | ${customUuid} | Resumen de reporte de credito ejecutado: ${JSON.stringify(scores)}`)
 
     reporteCredito.monto_solicitado = monto_solicitado
@@ -4337,7 +4341,7 @@ function serializeError(error) {
 }
 
 
-const sendEmailNodeMailer = async ({ info_email_error = null, info_email = null }) => {
+const sendEmailNodeMailer = async ({ info_email_error = null, info_email = null, rangos_bd = null }) => {
   const fileMethod = `file: src/controllers/api/certification.js - method: sendEmailNodeMailer`
   try {
     const globalConfig = await utilitiesService.getParametros()
@@ -4456,6 +4460,10 @@ ${JSON.stringify(info_email_error, null, 2)}
               ${detallesTabla}
             </tbody>
           </table>
+          ${rangos_bd ? `<h4 style="color: #337ab7;">Rangos BD</h4>
+          <pre style="background-color: #f5f5f5; padding: 10px; border: 1px solid #ddd; overflow-x: auto; white-space: pre;">
+${JSON.stringify(rangos_bd, null, 2)}
+          </pre>` : ''}
         </div>
       `
       logger.info(`${fileMethod} | La información del email es: ${JSON.stringify(info_email)}`)

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -1729,6 +1729,42 @@ WHERE cer.certificacion_id = (
     return result;
   }
 
+  async getAllAlgorithmRanges() {
+    const tables = [
+      'cat_pais_algoritmo',
+      'cat_sector_riesgo_sectorial_algoritmo',
+      'cat_sector_clientes_finales_algoritmo',
+      'cat_tiempo_actividad_comercial_algoritmo',
+      'cat_plantilla_laboral_algoritmo',
+      'cat_ventas_anuales_algoritmo',
+      'cat_apalancamiento_algoritmo',
+      'cat_flujo_neto_caja_algoritmo',
+      'cat_capital_contable_algoritmo',
+      'cat_incidencias_legales_algoritmo',
+      'cat_resultado_referencias_proveedores_algoritmo',
+      'cat_payback_algoritmo',
+      'cat_rotacion_cuentas_cobrar_algoritmo',
+      'cat_tipo_cifras_algoritmo',
+      'cat_evolucion_ventas_algoritmo',
+      'cat_score_descripcion_algoritmo'
+    ];
+
+    const results = {};
+
+    for (const table of tables) {
+      try {
+        const queryString = `SELECT * FROM ${table};`;
+        const { result } = await mysqlLib.query(queryString);
+        results[table] = result;
+      } catch (error) {
+        logger.error(`Error fetching ranges for table ${table}: ${error.message}`);
+        results[table] = [];
+      }
+    }
+
+    return results;
+  }
+
 
   async getCertificacion(id_certification) {
     const queryString = `


### PR DESCRIPTION
## Summary
- fetch algorithm ranges from database tables
- send ranges data by email when generating report

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ca2aaf04c832da78450134f9ff018