### PR TITLE
Add multi-line table cells

### DIFF
--- a/src/temp/plantillaInformativa.html
+++ b/src/temp/plantillaInformativa.html
@@ -10,6 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
       rel="stylesheet"
     />
+    <style>
+      td {
+        white-space: pre-line !important;
+      }
+    </style>
   </head>
   <body>
     <section


### PR DESCRIPTION
## Summary
- add CSS rule to allow multi-line table cells in plantillaInformativa.html

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ca67dbde8832d9a9481662609c27d