### PR TITLE
Add new algorithm module

### DIFF
--- a/src/controllers/api/algorithm.js
+++ b/src/controllers/api/algorithm.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const boom = require('boom')
+const algorithmService = require('../../services/algorithm')
+const logger = require('../../utils/logs/logger')
+
+const getAlgorithmResultV2 = async (req, res, next) => {
+  const fileMethod = 'file: src/controllers/api/algorithm.js - method: getAlgorithmResultV2'
+  try {
+    const { id_cliente, id_reporte_credito, monto_solicitado, plazo } = req.body
+
+    if (!id_cliente || !id_reporte_credito || !monto_solicitado || !plazo) {
+      return next(boom.badRequest('Información incompleta'))
+    }
+
+    const id_certification = await algorithmService.getLastCertificationId(id_cliente)
+    if (!id_certification) {
+      return next(boom.notFound('Certificación no encontrada'))
+    }
+
+    const data = await algorithmService.getInitialData(id_certification)
+    if (!data) {
+      return next(boom.badRequest('No se encontraron datos del algoritmo'))
+    }
+
+    const scores = {
+      paisScore: data.pais_score,
+      sectorRiesgoScore: data.sector_riesgo_score,
+      plantillaLaboralScore: data.plantilla_score,
+      sectorClienteFinalScore: data.sector_cliente_final_score,
+      tiempoActividadScore: data.tiempo_actividad_score
+    }
+
+    let g45 = 0
+    Object.values(scores).forEach(v => {
+      const val = parseInt(v, 10)
+      if (!isNaN(val)) g45 += val
+    })
+
+    const g46 = g45 * 0.0784 + 2.9834
+    const g49 = parseFloat((1 / (1 + Math.exp(-g46))).toFixed(4))
+    const g48 = 1 - g49
+    const g51 = g48 * 100
+    const g52 = g51 < 25 ? 'A' : g51 < 50 ? 'B' : 'C'
+
+    return res.json({
+      error: false,
+      id_certification,
+      scores,
+      g45,
+      g46,
+      g49,
+      g48,
+      g51,
+      g52
+    })
+  } catch (error) {
+    logger.error(`${fileMethod} | ${error.message}`)
+    next(error)
+  }
+}
+
+module.exports = {
+  getAlgorithmResultV2
+}

--- a/src/routes/api/algorithm.js
+++ b/src/routes/api/algorithm.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const express = require('express')
+const router = express.Router()
+
+const algorithmController = require('../../controllers/api/algorithm')
+
+router.post('/result', algorithmController.getAlgorithmResultV2)
+
+module.exports = router

--- a/src/services/algorithm.js
+++ b/src/services/algorithm.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const mysqlLib = require('../lib/db')
+
+class AlgorithmService {
+  async getLastCertificationId (clientId) {
+    const query = `
+      SELECT id_certification
+      FROM certification
+      WHERE id_empresa = ${mysqlLib.escape(clientId)}
+      ORDER BY id_certification DESC
+      LIMIT 1;
+    `
+    const { result } = await mysqlLib.query(query)
+    return result[0] ? result[0].id_certification : null
+  }
+
+  async getInitialData (id_certification) {
+    const query = `
+      SELECT
+        pa.nombre AS pais,
+        pa.valor_algoritmo AS pais_score,
+        srs.nombre AS sector_riesgo,
+        srs.valor_algoritmo AS sector_riesgo_score,
+        scf.nombre AS sector_cliente_final,
+        scf.valor_algoritmo AS sector_cliente_final_score,
+        tac.nombre AS tiempo_actividad,
+        tac.valor_algoritmo AS tiempo_actividad_score,
+        pla.nombre AS plantilla_nombre,
+        pla.valor_algoritmo AS plantilla_score
+      FROM certification AS c
+      LEFT JOIN cat_pais_algoritmo AS pa ON pa.id_pais_algoritmo = c.id_pais
+      LEFT JOIN cat_sector_riesgo_sectorial_algoritmo AS srs ON srs.id_cat_sector_riesgo_sectorial = c.id_cat_sector_riesgo_sectorial
+      LEFT JOIN cat_sector_clientes_finales_algoritmo AS scf ON scf.id_cat_sector_clientes_finales = c.id_cat_sector_clientes_finales
+      LEFT JOIN cat_tiempo_actividad_comercial_algoritmo AS tac ON tac.id_cat_tiempo_actividad_comercial = c.id_cat_tiempo_actividad_comercial
+      LEFT JOIN cat_plantilla_laboral_algoritmo AS pla ON c.plantilla_laboral BETWEEN pla.limite_inferior AND COALESCE(pla.limite_superior, c.plantilla_laboral)
+      WHERE c.id_certification = ${mysqlLib.escape(id_certification)}
+      LIMIT 1;
+    `
+    const { result } = await mysqlLib.query(query)
+    return result[0]
+  }
+}
+
+module.exports = new AlgorithmService()


### PR DESCRIPTION
## Summary
- implement standalone algorithm service and controller
- add new API route `/api/algorithm/result`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684cc1153d8c832da511d5a1215749d9