### PR TITLE
Fix Postman collection generation

### DIFF
--- a/generate_postman.js
+++ b/generate_postman.js
@@ -1,14 +1,16 @@
 const fs = require('fs');
 const path = require('path');
 
-const baseUrlVar = '{{baseUrl}}';
+// Base URL variable name for the collection
+const baseUrlVar = '{{dev}}';
 const collection = {
   info: {
     name: 'MC API',
     schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
   },
   item: [],
-  variable: [{ key: 'baseUrl', value: 'http://localhost:3000' }]
+  // Default value for the development server
+  variable: [{ key: 'dev', value: 'http://localhost:3000' }]
 };
 
 const routesDir = path.join(__dirname, 'src', 'routes', 'api');
@@ -16,22 +18,28 @@ const files = fs.readdirSync(routesDir).filter(f => f.endsWith('.js'));
 
 files.forEach(file => {
   const content = fs.readFileSync(path.join(routesDir, file), 'utf8');
-  const folder = { name: file.replace(/\.js$/, ''), item: [] };
+  const fileName = file.replace(/\.js$/, '');
+  const basePath = `/api/${fileName}`;
+  const folder = { name: fileName, item: [] };
   const regex = /router\.(get|post|put|delete|patch)\s*\(\s*['"]([^'"?]+)['"]/g;
   let match;
   while ((match = regex.exec(content)) !== null) {
     const method = match[1];
     const route = match[2];
+    const fullRoute = `${basePath}${route}`;
     folder.item.push({
-      name: `${method.toUpperCase()} ${route}`,
+      name: `${method.toUpperCase()} ${fullRoute}`,
       request: {
         method: method.toUpperCase(),
         header: [],
         url: {
-          raw: `${baseUrlVar}${route}`,
+          raw: `${baseUrlVar}${fullRoute}`,
           host: [baseUrlVar],
-          path: route.replace(/^\//, '').split('/').filter(Boolean)
-        }
+          path: fullRoute.replace(/^\//, '').split('/')
+        },
+        ...(method !== 'get' && method !== 'delete'
+          ? { body: { mode: 'raw', raw: '{}' } }
+          : {})
       }
     });
   }

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -8,18 +8,24 @@
       "name": "algorithm",
       "item": [
         {
-          "name": "POST /result",
+          "name": "POST /api/algorithm/result",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/result",
+              "raw": "{{dev}}/api/algorithm/result",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "algorithm",
                 "result"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -29,176 +35,234 @@
       "name": "auth.ga",
       "item": [
         {
-          "name": "POST /login",
+          "name": "POST /api/auth.ga/login",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/login",
+              "raw": "{{dev}}/api/auth.ga/login",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "login"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /refresh",
+          "name": "POST /api/auth.ga/refresh",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/refresh",
+              "raw": "{{dev}}/api/auth.ga/refresh",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "refresh"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /renewToken",
+          "name": "POST /api/auth.ga/renewToken",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/renewToken",
+              "raw": "{{dev}}/api/auth.ga/renewToken",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "renewToken"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /logout",
+          "name": "DELETE /api/auth.ga/logout",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/logout",
+              "raw": "{{dev}}/api/auth.ga/logout",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "logout"
               ]
             }
           }
         },
         {
-          "name": "POST /addModulo",
+          "name": "POST /api/auth.ga/addModulo",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/addModulo",
+              "raw": "{{dev}}/api/auth.ga/addModulo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "addModulo"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /addSubModulo",
+          "name": "POST /api/auth.ga/addSubModulo",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/addSubModulo",
+              "raw": "{{dev}}/api/auth.ga/addSubModulo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "addSubModulo"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /addComponente",
+          "name": "POST /api/auth.ga/addComponente",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/addComponente",
+              "raw": "{{dev}}/api/auth.ga/addComponente",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "addComponente"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /addSubComponente",
+          "name": "POST /api/auth.ga/addSubComponente",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/addSubComponente",
+              "raw": "{{dev}}/api/auth.ga/addSubComponente",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "addSubComponente"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /addRol",
+          "name": "POST /api/auth.ga/addRol",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/addRol",
+              "raw": "{{dev}}/api/auth.ga/addRol",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "addRol"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /addRolPermiso",
+          "name": "POST /api/auth.ga/addRolPermiso",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/addRolPermiso",
+              "raw": "{{dev}}/api/auth.ga/addRolPermiso",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "addRolPermiso"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getPermisos/:id_rol",
+          "name": "GET /api/auth.ga/getPermisos/:id_rol",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPermisos/:id_rol",
+              "raw": "{{dev}}/api/auth.ga/getPermisos/:id_rol",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "getPermisos",
                 ":id_rol"
               ]
@@ -206,163 +270,207 @@
           }
         },
         {
-          "name": "POST /encuestaLogin",
+          "name": "POST /api/auth.ga/encuestaLogin",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/encuestaLogin",
+              "raw": "{{dev}}/api/auth.ga/encuestaLogin",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "encuestaLogin"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /catMeGustaria",
+          "name": "GET /api/auth.ga/catMeGustaria",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/catMeGustaria",
+              "raw": "{{dev}}/api/auth.ga/catMeGustaria",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "catMeGustaria"
               ]
             }
           }
         },
         {
-          "name": "GET /catClientesCredito",
+          "name": "GET /api/auth.ga/catClientesCredito",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/catClientesCredito",
+              "raw": "{{dev}}/api/auth.ga/catClientesCredito",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "catClientesCredito"
               ]
             }
           }
         },
         {
-          "name": "GET /catRangoVentas",
+          "name": "GET /api/auth.ga/catRangoVentas",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/catRangoVentas",
+              "raw": "{{dev}}/api/auth.ga/catRangoVentas",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "catRangoVentas"
               ]
             }
           }
         },
         {
-          "name": "PUT /setTrueCronos/:id_empresa",
+          "name": "PUT /api/auth.ga/setTrueCronos/:id_empresa",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/setTrueCronos/:id_empresa",
+              "raw": "{{dev}}/api/auth.ga/setTrueCronos/:id_empresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "setTrueCronos",
                 ":id_empresa"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /catalogoCreditoClientes",
+          "name": "GET /api/auth.ga/catalogoCreditoClientes",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/catalogoCreditoClientes",
+              "raw": "{{dev}}/api/auth.ga/catalogoCreditoClientes",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "catalogoCreditoClientes"
               ]
             }
           }
         },
         {
-          "name": "POST /testCipher",
+          "name": "POST /api/auth.ga/testCipher",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/testCipher",
+              "raw": "{{dev}}/api/auth.ga/testCipher",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "testCipher"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /caso1",
+          "name": "POST /api/auth.ga/caso1",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/caso1",
+              "raw": "{{dev}}/api/auth.ga/caso1",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "caso1"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /caso2",
+          "name": "POST /api/auth.ga/caso2",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/caso2",
+              "raw": "{{dev}}/api/auth.ga/caso2",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "caso2"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /caso3",
+          "name": "POST /api/auth.ga/caso3",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/caso3",
+              "raw": "{{dev}}/api/auth.ga/caso3",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "auth.ga",
                 "caso3"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -372,32 +480,40 @@
       "name": "blog.ga",
       "item": [
         {
-          "name": "POST /articles",
+          "name": "POST /api/blog.ga/articles",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/articles",
+              "raw": "{{dev}}/api/blog.ga/articles",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "articles"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /articles/all",
+          "name": "GET /api/blog.ga/articles/all",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/articles/all",
+              "raw": "{{dev}}/api/blog.ga/articles/all",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "articles",
                 "all"
               ]
@@ -405,16 +521,18 @@
           }
         },
         {
-          "name": "GET /articles/ids",
+          "name": "GET /api/blog.ga/articles/ids",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/articles/ids",
+              "raw": "{{dev}}/api/blog.ga/articles/ids",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "articles",
                 "ids"
               ]
@@ -422,16 +540,18 @@
           }
         },
         {
-          "name": "GET /articles/search",
+          "name": "GET /api/blog.ga/articles/search",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/articles/search",
+              "raw": "{{dev}}/api/blog.ga/articles/search",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "articles",
                 "search"
               ]
@@ -439,16 +559,18 @@
           }
         },
         {
-          "name": "GET /articles/:artId",
+          "name": "GET /api/blog.ga/articles/:artId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/articles/:artId",
+              "raw": "{{dev}}/api/blog.ga/articles/:artId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "articles",
                 ":artId"
               ]
@@ -456,33 +578,41 @@
           }
         },
         {
-          "name": "PUT /articles/:artId",
+          "name": "PUT /api/blog.ga/articles/:artId",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/articles/:artId",
+              "raw": "{{dev}}/api/blog.ga/articles/:artId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "articles",
                 ":artId"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /comments/:artId",
+          "name": "GET /api/blog.ga/comments/:artId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comments/:artId",
+              "raw": "{{dev}}/api/blog.ga/comments/:artId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "comments",
                 ":artId"
               ]
@@ -490,51 +620,69 @@
           }
         },
         {
-          "name": "POST /comments",
+          "name": "POST /api/blog.ga/comments",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comments",
+              "raw": "{{dev}}/api/blog.ga/comments",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "comments"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /comments/subcomments",
+          "name": "POST /api/blog.ga/comments/subcomments",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comments/subcomments",
+              "raw": "{{dev}}/api/blog.ga/comments/subcomments",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "comments",
                 "subcomments"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /stats",
+          "name": "POST /api/blog.ga/stats",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/stats",
+              "raw": "{{dev}}/api/blog.ga/stats",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "blog.ga",
                 "stats"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -544,46 +692,62 @@
       "name": "certification",
       "item": [
         {
-          "name": "POST /",
+          "name": "POST /api/certification/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/certification/",
               "host": [
-                "{{baseUrl}}"
-              ],
-              "path": []
-            }
-          }
-        },
-        {
-          "name": "POST /documentosCertificacion",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/documentosCertificacion",
-              "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
-                "documentosCertificacion"
+                "api",
+                "certification",
+                ""
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /infoCertificacion/:idEmpresa/:idSeccion",
+          "name": "POST /api/certification/documentosCertificacion",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{dev}}/api/certification/documentosCertificacion",
+              "host": [
+                "{{dev}}"
+              ],
+              "path": [
+                "api",
+                "certification",
+                "documentosCertificacion"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "GET /api/certification/infoCertificacion/:idEmpresa/:idSeccion",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/infoCertificacion/:idEmpresa/:idSeccion",
+              "raw": "{{dev}}/api/certification/infoCertificacion/:idEmpresa/:idSeccion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "infoCertificacion",
                 ":idEmpresa",
                 ":idSeccion"
@@ -592,144 +756,190 @@
           }
         },
         {
-          "name": "GET /data",
+          "name": "GET /api/certification/data",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/data",
+              "raw": "{{dev}}/api/certification/data",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "data"
               ]
             }
           }
         },
         {
-          "name": "POST /payment",
+          "name": "POST /api/certification/payment",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/payment",
+              "raw": "{{dev}}/api/certification/payment",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "payment"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /certificar",
+          "name": "POST /api/certification/certificar",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/certificar",
+              "raw": "{{dev}}/api/certification/certificar",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "certificar"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /certificar-reset",
+          "name": "POST /api/certification/certificar-reset",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/certificar-reset",
+              "raw": "{{dev}}/api/certification/certificar-reset",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "certificar-reset"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /iniciaCertificacion",
+          "name": "POST /api/certification/iniciaCertificacion",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/iniciaCertificacion",
+              "raw": "{{dev}}/api/certification/iniciaCertificacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "iniciaCertificacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /guardaPartidasFinancieras",
+          "name": "POST /api/certification/guardaPartidasFinancieras",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/guardaPartidasFinancieras",
+              "raw": "{{dev}}/api/certification/guardaPartidasFinancieras",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "guardaPartidasFinancieras"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /guardaMercadoObjetivo",
+          "name": "POST /api/certification/guardaMercadoObjetivo",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/guardaMercadoObjetivo",
+              "raw": "{{dev}}/api/certification/guardaMercadoObjetivo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "guardaMercadoObjetivo"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /guardaReferenciasComerciales",
+          "name": "POST /api/certification/guardaReferenciasComerciales",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/guardaReferenciasComerciales",
+              "raw": "{{dev}}/api/certification/guardaReferenciasComerciales",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "guardaReferenciasComerciales"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getReferenciaComercialForm/:id_certification",
+          "name": "GET /api/certification/getReferenciaComercialForm/:id_certification",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getReferenciaComercialForm/:id_certification",
+              "raw": "{{dev}}/api/certification/getReferenciaComercialForm/:id_certification",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getReferenciaComercialForm",
                 ":id_certification"
               ]
@@ -737,160 +947,192 @@
           }
         },
         {
-          "name": "GET /getIndustria",
+          "name": "GET /api/certification/getIndustria",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getIndustria",
+              "raw": "{{dev}}/api/certification/getIndustria",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getIndustria"
               ]
             }
           }
         },
         {
-          "name": "GET /getPaisAlgoritmo",
+          "name": "GET /api/certification/getPaisAlgoritmo",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPaisAlgoritmo",
+              "raw": "{{dev}}/api/certification/getPaisAlgoritmo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getPaisAlgoritmo"
               ]
             }
           }
         },
         {
-          "name": "GET /getSectorRiesgoSectorialAlgoritmo",
+          "name": "GET /api/certification/getSectorRiesgoSectorialAlgoritmo",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getSectorRiesgoSectorialAlgoritmo",
+              "raw": "{{dev}}/api/certification/getSectorRiesgoSectorialAlgoritmo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getSectorRiesgoSectorialAlgoritmo"
               ]
             }
           }
         },
         {
-          "name": "GET /getSectorClientesFinalesAlgoritmo",
+          "name": "GET /api/certification/getSectorClientesFinalesAlgoritmo",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getSectorClientesFinalesAlgoritmo",
+              "raw": "{{dev}}/api/certification/getSectorClientesFinalesAlgoritmo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getSectorClientesFinalesAlgoritmo"
               ]
             }
           }
         },
         {
-          "name": "GET /getTiempoActividadComercialAlgoritmo",
+          "name": "GET /api/certification/getTiempoActividadComercialAlgoritmo",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getTiempoActividadComercialAlgoritmo",
+              "raw": "{{dev}}/api/certification/getTiempoActividadComercialAlgoritmo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getTiempoActividadComercialAlgoritmo"
               ]
             }
           }
         },
         {
-          "name": "GET /getTipoCifrasAlgoritmo",
+          "name": "GET /api/certification/getTipoCifrasAlgoritmo",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getTipoCifrasAlgoritmo",
+              "raw": "{{dev}}/api/certification/getTipoCifrasAlgoritmo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getTipoCifrasAlgoritmo"
               ]
             }
           }
         },
         {
-          "name": "POST /getResultAlgoritmo",
+          "name": "POST /api/certification/getResultAlgoritmo",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getResultAlgoritmo",
+              "raw": "{{dev}}/api/certification/getResultAlgoritmo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getResultAlgoritmo"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /generaReporteInformativoCredito",
+          "name": "POST /api/certification/generaReporteInformativoCredito",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/generaReporteInformativoCredito",
+              "raw": "{{dev}}/api/certification/generaReporteInformativoCredito",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "generaReporteInformativoCredito"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /validacionBloc",
+          "name": "POST /api/certification/validacionBloc",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/validacionBloc",
+              "raw": "{{dev}}/api/certification/validacionBloc",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "validacionBloc"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /consultaBloc/:idEmpresa",
+          "name": "GET /api/certification/consultaBloc/:idEmpresa",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/consultaBloc/:idEmpresa",
+              "raw": "{{dev}}/api/certification/consultaBloc/:idEmpresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "consultaBloc",
                 ":idEmpresa"
               ]
@@ -898,16 +1140,18 @@
           }
         },
         {
-          "name": "GET /checkInfoAlgoritmo/:id_certification",
+          "name": "GET /api/certification/checkInfoAlgoritmo/:id_certification",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/checkInfoAlgoritmo/:id_certification",
+              "raw": "{{dev}}/api/certification/checkInfoAlgoritmo/:id_certification",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "checkInfoAlgoritmo",
                 ":id_certification"
               ]
@@ -915,16 +1159,18 @@
           }
         },
         {
-          "name": "GET /getPais/:tipo",
+          "name": "GET /api/certification/getPais/:tipo",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPais/:tipo",
+              "raw": "{{dev}}/api/certification/getPais/:tipo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getPais",
                 ":tipo"
               ]
@@ -932,128 +1178,156 @@
           }
         },
         {
-          "name": "GET /getDenominaciones",
+          "name": "GET /api/certification/getDenominaciones",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getDenominaciones",
+              "raw": "{{dev}}/api/certification/getDenominaciones",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getDenominaciones"
               ]
             }
           }
         },
         {
-          "name": "GET /getPuestos",
+          "name": "GET /api/certification/getPuestos",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPuestos",
+              "raw": "{{dev}}/api/certification/getPuestos",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getPuestos"
               ]
             }
           }
         },
         {
-          "name": "GET /getPoderes",
+          "name": "GET /api/certification/getPoderes",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPoderes",
+              "raw": "{{dev}}/api/certification/getPoderes",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getPoderes"
               ]
             }
           }
         },
         {
-          "name": "GET /getBienesAsegurados",
+          "name": "GET /api/certification/getBienesAsegurados",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getBienesAsegurados",
+              "raw": "{{dev}}/api/certification/getBienesAsegurados",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getBienesAsegurados"
               ]
             }
           }
         },
         {
-          "name": "PUT /updateCertificacion",
+          "name": "PUT /api/certification/updateCertificacion",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/updateCertificacion",
+              "raw": "{{dev}}/api/certification/updateCertificacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "updateCertificacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /updatePartidasFinancieras",
+          "name": "PUT /api/certification/updatePartidasFinancieras",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/updatePartidasFinancieras",
+              "raw": "{{dev}}/api/certification/updatePartidasFinancieras",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "updatePartidasFinancieras"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /updateReferenciasComerciales",
+          "name": "PUT /api/certification/updateReferenciasComerciales",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/updateReferenciasComerciales",
+              "raw": "{{dev}}/api/certification/updateReferenciasComerciales",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "updateReferenciasComerciales"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getCertification/:idEmpresa",
+          "name": "GET /api/certification/getCertification/:idEmpresa",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getCertification/:idEmpresa",
+              "raw": "{{dev}}/api/certification/getCertification/:idEmpresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getCertification",
                 ":idEmpresa"
               ]
@@ -1061,16 +1335,18 @@
           }
         },
         {
-          "name": "GET /getCertificationStatus/:idEmpresa",
+          "name": "GET /api/certification/getCertificationStatus/:idEmpresa",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getCertificationStatus/:idEmpresa",
+              "raw": "{{dev}}/api/certification/getCertificationStatus/:idEmpresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getCertificationStatus",
                 ":idEmpresa"
               ]
@@ -1078,32 +1354,40 @@
           }
         },
         {
-          "name": "POST /uploadDocumentoCertificacion",
+          "name": "POST /api/certification/uploadDocumentoCertificacion",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/uploadDocumentoCertificacion",
+              "raw": "{{dev}}/api/certification/uploadDocumentoCertificacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "uploadDocumentoCertificacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /consultaDocumento/:id_empresa",
+          "name": "GET /api/certification/consultaDocumento/:id_empresa",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/consultaDocumento/:id_empresa",
+              "raw": "{{dev}}/api/certification/consultaDocumento/:id_empresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "consultaDocumento",
                 ":id_empresa"
               ]
@@ -1111,96 +1395,124 @@
           }
         },
         {
-          "name": "PUT /updateDocumento",
+          "name": "PUT /api/certification/updateDocumento",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/updateDocumento",
+              "raw": "{{dev}}/api/certification/updateDocumento",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "updateDocumento"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /deleteDocumento",
+          "name": "DELETE /api/certification/deleteDocumento",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/deleteDocumento",
+              "raw": "{{dev}}/api/certification/deleteDocumento",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "deleteDocumento"
               ]
             }
           }
         },
         {
-          "name": "POST /consultaCronos",
+          "name": "POST /api/certification/consultaCronos",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/consultaCronos",
+              "raw": "{{dev}}/api/certification/consultaCronos",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "consultaCronos"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /setStatusCertification",
+          "name": "PUT /api/certification/setStatusCertification",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/setStatusCertification",
+              "raw": "{{dev}}/api/certification/setStatusCertification",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "setStatusCertification"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /downloadLogs",
+          "name": "POST /api/certification/downloadLogs",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/downloadLogs",
+              "raw": "{{dev}}/api/certification/downloadLogs",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "downloadLogs"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /informacionContacto/:id_contacto",
+          "name": "GET /api/certification/informacionContacto/:id_contacto",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/informacionContacto/:id_contacto",
+              "raw": "{{dev}}/api/certification/informacionContacto/:id_contacto",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "informacionContacto",
                 ":id_contacto"
               ]
@@ -1208,32 +1520,40 @@
           }
         },
         {
-          "name": "PUT /updateInformacionContacto",
+          "name": "PUT /api/certification/updateInformacionContacto",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/updateInformacionContacto",
+              "raw": "{{dev}}/api/certification/updateInformacionContacto",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "updateInformacionContacto"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getInfoContactoReferido/:id_contacto",
+          "name": "GET /api/certification/getInfoContactoReferido/:id_contacto",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getInfoContactoReferido/:id_contacto",
+              "raw": "{{dev}}/api/certification/getInfoContactoReferido/:id_contacto",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getInfoContactoReferido",
                 ":id_contacto"
               ]
@@ -1241,32 +1561,40 @@
           }
         },
         {
-          "name": "POST /solicitarCredito",
+          "name": "POST /api/certification/solicitarCredito",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/solicitarCredito",
+              "raw": "{{dev}}/api/certification/solicitarCredito",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "solicitarCredito"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getMontoPlazo/:id_proveedor/:id_cliente/:id_solicitud_credito",
+          "name": "GET /api/certification/getMontoPlazo/:id_proveedor/:id_cliente/:id_solicitud_credito",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getMontoPlazo/:id_proveedor/:id_cliente/:id_solicitud_credito",
+              "raw": "{{dev}}/api/certification/getMontoPlazo/:id_proveedor/:id_cliente/:id_solicitud_credito",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getMontoPlazo",
                 ":id_proveedor",
                 ":id_cliente",
@@ -1276,32 +1604,40 @@
           }
         },
         {
-          "name": "PUT /seteaEstatusSolicitudCredito",
+          "name": "PUT /api/certification/seteaEstatusSolicitudCredito",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/seteaEstatusSolicitudCredito",
+              "raw": "{{dev}}/api/certification/seteaEstatusSolicitudCredito",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "seteaEstatusSolicitudCredito"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /obtenerInfoReferenciaExterna/:hash",
+          "name": "GET /api/certification/obtenerInfoReferenciaExterna/:hash",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/obtenerInfoReferenciaExterna/:hash",
+              "raw": "{{dev}}/api/certification/obtenerInfoReferenciaExterna/:hash",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "obtenerInfoReferenciaExterna",
                 ":hash"
               ]
@@ -1309,64 +1645,84 @@
           }
         },
         {
-          "name": "PUT /actualizaHashReferenciaExternas",
+          "name": "PUT /api/certification/actualizaHashReferenciaExternas",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/actualizaHashReferenciaExternas",
+              "raw": "{{dev}}/api/certification/actualizaHashReferenciaExternas",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "actualizaHashReferenciaExternas"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /consultaMailjet",
+          "name": "POST /api/certification/consultaMailjet",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/consultaMailjet",
+              "raw": "{{dev}}/api/certification/consultaMailjet",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "consultaMailjet"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /saveLog",
+          "name": "POST /api/certification/saveLog",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/saveLog",
+              "raw": "{{dev}}/api/certification/saveLog",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "saveLog"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getDataReporteGlobal/:id_emp",
+          "name": "GET /api/certification/getDataReporteGlobal/:id_emp",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getDataReporteGlobal/:id_emp",
+              "raw": "{{dev}}/api/certification/getDataReporteGlobal/:id_emp",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "certification",
                 "getDataReporteGlobal",
                 ":id_emp"
               ]
@@ -1379,108 +1735,131 @@
       "name": "companies",
       "item": [
         {
-          "name": "GET /actualizaListaContactos/",
+          "name": "GET /api/companies/actualizaListaContactos/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/actualizaListaContactos/",
+              "raw": "{{dev}}/api/companies/actualizaListaContactos/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
-                "actualizaListaContactos"
+                "api",
+                "companies",
+                "actualizaListaContactos",
+                ""
               ]
             }
           }
         },
         {
-          "name": "GET /getEval:id",
+          "name": "GET /api/companies/getEval:id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getEval:id",
+              "raw": "{{dev}}/api/companies/getEval:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 "getEval:id"
               ]
             }
           }
         },
         {
-          "name": "GET /",
+          "name": "GET /api/companies/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/companies/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "companies",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "POST /",
+          "name": "POST /api/companies/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/companies/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "companies",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /favorites",
+          "name": "GET /api/companies/favorites",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/favorites",
+              "raw": "{{dev}}/api/companies/favorites",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 "favorites"
               ]
             }
           }
         },
         {
-          "name": "GET /:id",
+          "name": "GET /api/companies/:id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id",
+              "raw": "{{dev}}/api/companies/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id"
               ]
             }
           }
         },
         {
-          "name": "GET /getCompanyById/:id",
+          "name": "GET /api/companies/getCompanyById/:id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getCompanyById/:id",
+              "raw": "{{dev}}/api/companies/getCompanyById/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 "getCompanyById",
                 ":id"
               ]
@@ -1488,133 +1867,177 @@
           }
         },
         {
-          "name": "PUT /:id",
+          "name": "PUT /api/companies/:id",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id",
+              "raw": "{{dev}}/api/companies/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /:id",
+          "name": "PUT /api/companies/:id",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id",
+              "raw": "{{dev}}/api/companies/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /:id",
+          "name": "PUT /api/companies/:id",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id",
+              "raw": "{{dev}}/api/companies/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /:id/schedules",
+          "name": "POST /api/companies/:id/schedules",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/schedules",
+              "raw": "{{dev}}/api/companies/:id/schedules",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "schedules"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /:id/schedules",
+          "name": "PUT /api/companies/:id/schedules",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/schedules",
+              "raw": "{{dev}}/api/companies/:id/schedules",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "schedules"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /:id/addresses",
+          "name": "POST /api/companies/:id/addresses",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/addresses",
+              "raw": "{{dev}}/api/companies/:id/addresses",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "addresses"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /:id/addresses/:address",
+          "name": "PUT /api/companies/:id/addresses/:address",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/addresses/:address",
+              "raw": "{{dev}}/api/companies/:id/addresses/:address",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "addresses",
                 ":address"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /:id/addresses",
+          "name": "DELETE /api/companies/:id/addresses",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/addresses",
+              "raw": "{{dev}}/api/companies/:id/addresses",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "addresses"
               ]
@@ -1622,54 +2045,68 @@
           }
         },
         {
-          "name": "PUT /:id/addresses/:address/corporate",
+          "name": "PUT /api/companies/:id/addresses/:address/corporate",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/addresses/:address/corporate",
+              "raw": "{{dev}}/api/companies/:id/addresses/:address/corporate",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "addresses",
                 ":address",
                 "corporate"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /:id/addresses/:address/phones",
+          "name": "POST /api/companies/:id/addresses/:address/phones",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/addresses/:address/phones",
+              "raw": "{{dev}}/api/companies/:id/addresses/:address/phones",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "addresses",
                 ":address",
                 "phones"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /:id/addresses/:address/phones",
+          "name": "DELETE /api/companies/:id/addresses/:address/phones",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/addresses/:address/phones",
+              "raw": "{{dev}}/api/companies/:id/addresses/:address/phones",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "addresses",
                 ":address",
@@ -1679,36 +2116,44 @@
           }
         },
         {
-          "name": "PUT /:id/addresses/:address/phones/:phone",
+          "name": "PUT /api/companies/:id/addresses/:address/phones/:phone",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/addresses/:address/phones/:phone",
+              "raw": "{{dev}}/api/companies/:id/addresses/:address/phones/:phone",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "addresses",
                 ":address",
                 "phones",
                 ":phone"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /:id/users",
+          "name": "GET /api/companies/:id/users",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/users",
+              "raw": "{{dev}}/api/companies/:id/users",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "users"
               ]
@@ -1716,50 +2161,64 @@
           }
         },
         {
-          "name": "POST /:id/users",
+          "name": "POST /api/companies/:id/users",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/users",
+              "raw": "{{dev}}/api/companies/:id/users",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "users"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /:id/users",
+          "name": "PUT /api/companies/:id/users",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/users",
+              "raw": "{{dev}}/api/companies/:id/users",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "users"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /:id/users-invitations",
+          "name": "GET /api/companies/:id/users-invitations",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/users-invitations",
+              "raw": "{{dev}}/api/companies/:id/users-invitations",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "users-invitations"
               ]
@@ -1767,33 +2226,41 @@
           }
         },
         {
-          "name": "POST /:id/users-invitations",
+          "name": "POST /api/companies/:id/users-invitations",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/users-invitations",
+              "raw": "{{dev}}/api/companies/:id/users-invitations",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "users-invitations"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /:id/users-invitations",
+          "name": "DELETE /api/companies/:id/users-invitations",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/users-invitations",
+              "raw": "{{dev}}/api/companies/:id/users-invitations",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "users-invitations"
               ]
@@ -1801,50 +2268,64 @@
           }
         },
         {
-          "name": "PUT /:id/users-invitations",
+          "name": "PUT /api/companies/:id/users-invitations",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/users-invitations",
+              "raw": "{{dev}}/api/companies/:id/users-invitations",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "users-invitations"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /:id/users-details",
+          "name": "PUT /api/companies/:id/users-details",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/users-details",
+              "raw": "{{dev}}/api/companies/:id/users-details",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "users-details"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /:id/products",
+          "name": "GET /api/companies/:id/products",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/products",
+              "raw": "{{dev}}/api/companies/:id/products",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":id",
                 "products"
               ]
@@ -1852,16 +2333,18 @@
           }
         },
         {
-          "name": "GET /:companyID/events",
+          "name": "GET /api/companies/:companyID/events",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:companyID/events",
+              "raw": "{{dev}}/api/companies/:companyID/events",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":companyID",
                 "events"
               ]
@@ -1869,32 +2352,40 @@
           }
         },
         {
-          "name": "POST /favorites",
+          "name": "POST /api/companies/favorites",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/favorites",
+              "raw": "{{dev}}/api/companies/favorites",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 "favorites"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /:companyID/ratings",
+          "name": "GET /api/companies/:companyID/ratings",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:companyID/ratings",
+              "raw": "{{dev}}/api/companies/:companyID/ratings",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":companyID",
                 "ratings"
               ]
@@ -1902,52 +2393,70 @@
           }
         },
         {
-          "name": "POST /:companyID/videos",
+          "name": "POST /api/companies/:companyID/videos",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:companyID/videos",
+              "raw": "{{dev}}/api/companies/:companyID/videos",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 ":companyID",
                 "videos"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /addresses/createandupdate",
+          "name": "POST /api/companies/addresses/createandupdate",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/addresses/createandupdate",
+              "raw": "{{dev}}/api/companies/addresses/createandupdate",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 "addresses",
                 "createandupdate"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /invitacion",
+          "name": "POST /api/companies/invitacion",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/invitacion",
+              "raw": "{{dev}}/api/companies/invitacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "companies",
                 "invitacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -1957,30 +2466,36 @@
       "name": "cotizacion",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/cotizacion/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/cotizacion/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "cotizacion",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /fecha/:id/:dias",
+          "name": "GET /api/cotizacion/fecha/:id/:dias",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fecha/:id/:dias",
+              "raw": "{{dev}}/api/cotizacion/fecha/:id/:dias",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "fecha",
                 ":id",
                 ":dias"
@@ -1989,64 +2504,72 @@
           }
         },
         {
-          "name": "GET /comprobantes",
+          "name": "GET /api/cotizacion/comprobantes",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comprobantes",
+              "raw": "{{dev}}/api/cotizacion/comprobantes",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "comprobantes"
               ]
             }
           }
         },
         {
-          "name": "GET /pdf",
+          "name": "GET /api/cotizacion/pdf",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/pdf",
+              "raw": "{{dev}}/api/cotizacion/pdf",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "pdf"
               ]
             }
           }
         },
         {
-          "name": "GET /:cotId",
+          "name": "GET /api/cotizacion/:cotId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:cotId",
+              "raw": "{{dev}}/api/cotizacion/:cotId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 ":cotId"
               ]
             }
           }
         },
         {
-          "name": "GET /productos/:cotId",
+          "name": "GET /api/cotizacion/productos/:cotId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/productos/:cotId",
+              "raw": "{{dev}}/api/cotizacion/productos/:cotId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "productos",
                 ":cotId"
               ]
@@ -2054,62 +2577,84 @@
           }
         },
         {
-          "name": "POST /",
+          "name": "POST /api/cotizacion/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/cotizacion/",
               "host": [
-                "{{baseUrl}}"
-              ],
-              "path": []
-            }
-          }
-        },
-        {
-          "name": "POST /crearCotizacion",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/crearCotizacion",
-              "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
-                "crearCotizacion"
+                "api",
+                "cotizacion",
+                ""
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /actualizaCotizacion",
+          "name": "POST /api/cotizacion/crearCotizacion",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{dev}}/api/cotizacion/crearCotizacion",
+              "host": [
+                "{{dev}}"
+              ],
+              "path": [
+                "api",
+                "cotizacion",
+                "crearCotizacion"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "PUT /api/cotizacion/actualizaCotizacion",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/actualizaCotizacion",
+              "raw": "{{dev}}/api/cotizacion/actualizaCotizacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "actualizaCotizacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getEmpresas/:emp",
+          "name": "GET /api/cotizacion/getEmpresas/:emp",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getEmpresas/:emp",
+              "raw": "{{dev}}/api/cotizacion/getEmpresas/:emp",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "getEmpresas",
                 ":emp"
               ]
@@ -2117,16 +2662,18 @@
           }
         },
         {
-          "name": "GET /getCotizacion/:user",
+          "name": "GET /api/cotizacion/getCotizacion/:user",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getCotizacion/:user",
+              "raw": "{{dev}}/api/cotizacion/getCotizacion/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "getCotizacion",
                 ":user"
               ]
@@ -2134,16 +2681,18 @@
           }
         },
         {
-          "name": "GET /getProductos/:cotId",
+          "name": "GET /api/cotizacion/getProductos/:cotId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getProductos/:cotId",
+              "raw": "{{dev}}/api/cotizacion/getProductos/:cotId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "getProductos",
                 ":cotId"
               ]
@@ -2151,16 +2700,18 @@
           }
         },
         {
-          "name": "GET /getBitacora/:cotId",
+          "name": "GET /api/cotizacion/getBitacora/:cotId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getBitacora/:cotId",
+              "raw": "{{dev}}/api/cotizacion/getBitacora/:cotId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "getBitacora",
                 ":cotId"
               ]
@@ -2168,16 +2719,18 @@
           }
         },
         {
-          "name": "GET /getUsuarios/:cotizacion",
+          "name": "GET /api/cotizacion/getUsuarios/:cotizacion",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getUsuarios/:cotizacion",
+              "raw": "{{dev}}/api/cotizacion/getUsuarios/:cotizacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "getUsuarios",
                 ":cotizacion"
               ]
@@ -2185,33 +2738,41 @@
           }
         },
         {
-          "name": "PUT /update/:cotId",
+          "name": "PUT /api/cotizacion/update/:cotId",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/update/:cotId",
+              "raw": "{{dev}}/api/cotizacion/update/:cotId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "update",
                 ":cotId"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /bitacora/:cotId",
+          "name": "GET /api/cotizacion/bitacora/:cotId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/bitacora/:cotId",
+              "raw": "{{dev}}/api/cotizacion/bitacora/:cotId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "bitacora",
                 ":cotId"
               ]
@@ -2219,16 +2780,18 @@
           }
         },
         {
-          "name": "GET /reportes/pagos/:reporte",
+          "name": "GET /api/cotizacion/reportes/pagos/:reporte",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes/pagos/:reporte",
+              "raw": "{{dev}}/api/cotizacion/reportes/pagos/:reporte",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes",
                 "pagos",
                 ":reporte"
@@ -2237,50 +2800,64 @@
           }
         },
         {
-          "name": "POST /reportes/pagos",
+          "name": "POST /api/cotizacion/reportes/pagos",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes/pagos",
+              "raw": "{{dev}}/api/cotizacion/reportes/pagos",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes",
                 "pagos"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /reportes/pagos",
+          "name": "PUT /api/cotizacion/reportes/pagos",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes/pagos",
+              "raw": "{{dev}}/api/cotizacion/reportes/pagos",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes",
                 "pagos"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /reportes/pagos/:id",
+          "name": "DELETE /api/cotizacion/reportes/pagos/:id",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes/pagos/:id",
+              "raw": "{{dev}}/api/cotizacion/reportes/pagos/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes",
                 "pagos",
                 ":id"
@@ -2289,112 +2866,138 @@
           }
         },
         {
-          "name": "POST /reportes",
+          "name": "POST /api/cotizacion/reportes",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes",
+              "raw": "{{dev}}/api/cotizacion/reportes",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /reportes",
+          "name": "PUT /api/cotizacion/reportes",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes",
+              "raw": "{{dev}}/api/cotizacion/reportes",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /reportes",
+          "name": "DELETE /api/cotizacion/reportes",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes",
+              "raw": "{{dev}}/api/cotizacion/reportes",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes"
               ]
             }
           }
         },
         {
-          "name": "POST /comentarios",
+          "name": "POST /api/cotizacion/comentarios",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios",
+              "raw": "{{dev}}/api/cotizacion/comentarios",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "comentarios"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /comentarios",
+          "name": "DELETE /api/cotizacion/comentarios",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios",
+              "raw": "{{dev}}/api/cotizacion/comentarios",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "comentarios"
               ]
             }
           }
         },
         {
-          "name": "GET /reportes",
+          "name": "GET /api/cotizacion/reportes",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes",
+              "raw": "{{dev}}/api/cotizacion/reportes",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes"
               ]
             }
           }
         },
         {
-          "name": "GET /reportes/:id",
+          "name": "GET /api/cotizacion/reportes/:id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reportes/:id",
+              "raw": "{{dev}}/api/cotizacion/reportes/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "reportes",
                 ":id"
               ]
@@ -2402,32 +3005,40 @@
           }
         },
         {
-          "name": "PUT /:cotId",
+          "name": "PUT /api/cotizacion/:cotId",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:cotId",
+              "raw": "{{dev}}/api/cotizacion/:cotId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 ":cotId"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /comentarios/:id",
+          "name": "GET /api/cotizacion/comentarios/:id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios/:id",
+              "raw": "{{dev}}/api/cotizacion/comentarios/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "comentarios",
                 ":id"
               ]
@@ -2435,16 +3046,18 @@
           }
         },
         {
-          "name": "GET /comentarios/sin-leer/:id",
+          "name": "GET /api/cotizacion/comentarios/sin-leer/:id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios/sin-leer/:id",
+              "raw": "{{dev}}/api/cotizacion/comentarios/sin-leer/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "comentarios",
                 "sin-leer",
                 ":id"
@@ -2453,67 +3066,87 @@
           }
         },
         {
-          "name": "PUT /comentarios/sin-leer/:id",
+          "name": "PUT /api/cotizacion/comentarios/sin-leer/:id",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios/sin-leer/:id",
+              "raw": "{{dev}}/api/cotizacion/comentarios/sin-leer/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "comentarios",
                 "sin-leer",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /experiencias",
+          "name": "POST /api/cotizacion/experiencias",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/experiencias",
+              "raw": "{{dev}}/api/cotizacion/experiencias",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "experiencias"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /experiencias/:id",
+          "name": "PUT /api/cotizacion/experiencias/:id",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/experiencias/:id",
+              "raw": "{{dev}}/api/cotizacion/experiencias/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "experiencias",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /actualizacion/:id",
+          "name": "GET /api/cotizacion/actualizacion/:id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/actualizacion/:id",
+              "raw": "{{dev}}/api/cotizacion/actualizacion/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "actualizacion",
                 ":id"
               ]
@@ -2521,16 +3154,18 @@
           }
         },
         {
-          "name": "GET /usuarios/:cotizacion",
+          "name": "GET /api/cotizacion/usuarios/:cotizacion",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/usuarios/:cotizacion",
+              "raw": "{{dev}}/api/cotizacion/usuarios/:cotizacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "usuarios",
                 ":cotizacion"
               ]
@@ -2538,32 +3173,40 @@
           }
         },
         {
-          "name": "POST /comprobantes",
+          "name": "POST /api/cotizacion/comprobantes",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comprobantes",
+              "raw": "{{dev}}/api/cotizacion/comprobantes",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "comprobantes"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /por-pagar/:userID",
+          "name": "GET /api/cotizacion/por-pagar/:userID",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/por-pagar/:userID",
+              "raw": "{{dev}}/api/cotizacion/por-pagar/:userID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "por-pagar",
                 ":userID"
               ]
@@ -2571,16 +3214,18 @@
           }
         },
         {
-          "name": "GET /success/get",
+          "name": "GET /api/cotizacion/success/get",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/success/get",
+              "raw": "{{dev}}/api/cotizacion/success/get",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "cotizacion",
                 "success",
                 "get"
               ]
@@ -2593,30 +3238,36 @@
       "name": "countries",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/countries/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/countries/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "countries",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /:id/states",
+          "name": "GET /api/countries/:id/states",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:id/states",
+              "raw": "{{dev}}/api/countries/:id/states",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "countries",
                 ":id",
                 "states"
               ]
@@ -2629,49 +3280,63 @@
       "name": "credit-reports",
       "item": [
         {
-          "name": "POST /ask",
+          "name": "POST /api/credit-reports/ask",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/ask",
+              "raw": "{{dev}}/api/credit-reports/ask",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "credit-reports",
                 "ask"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /report/:reportID",
+          "name": "PUT /api/credit-reports/report/:reportID",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/report/:reportID",
+              "raw": "{{dev}}/api/credit-reports/report/:reportID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "credit-reports",
                 "report",
                 ":reportID"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /report/:reportID",
+          "name": "GET /api/credit-reports/report/:reportID",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/report/:reportID",
+              "raw": "{{dev}}/api/credit-reports/report/:reportID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "credit-reports",
                 "report",
                 ":reportID"
               ]
@@ -2679,32 +3344,40 @@
           }
         },
         {
-          "name": "POST /pay",
+          "name": "POST /api/credit-reports/pay",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/pay",
+              "raw": "{{dev}}/api/credit-reports/pay",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "credit-reports",
                 "pay"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getPaymentType",
+          "name": "GET /api/credit-reports/getPaymentType",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPaymentType",
+              "raw": "{{dev}}/api/credit-reports/getPaymentType",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "credit-reports",
                 "getPaymentType"
               ]
             }
@@ -2716,16 +3389,20 @@
       "name": "currencies",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/currencies/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/currencies/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "currencies",
+                ""
+              ]
             }
           }
         }
@@ -2735,126 +3412,162 @@
       "name": "events",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/events/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/events/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "events",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "POST /",
+          "name": "POST /api/events/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/events/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "events",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /:eventoID",
+          "name": "GET /api/events/:eventoID",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:eventoID",
+              "raw": "{{dev}}/api/events/:eventoID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 ":eventoID"
               ]
             }
           }
         },
         {
-          "name": "PUT /:eventoID",
+          "name": "PUT /api/events/:eventoID",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:eventoID",
+              "raw": "{{dev}}/api/events/:eventoID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 ":eventoID"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /:eventID",
+          "name": "DELETE /api/events/:eventID",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:eventID",
+              "raw": "{{dev}}/api/events/:eventID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 ":eventID"
               ]
             }
           }
         },
         {
-          "name": "POST /:eventoID/invitations",
+          "name": "POST /api/events/:eventoID/invitations",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:eventoID/invitations",
+              "raw": "{{dev}}/api/events/:eventoID/invitations",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 ":eventoID",
                 "invitations"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /:eventoID/favorite",
+          "name": "POST /api/events/:eventoID/favorite",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:eventoID/favorite",
+              "raw": "{{dev}}/api/events/:eventoID/favorite",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 ":eventoID",
                 "favorite"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /:eventoID/schedules/:scheduleID",
+          "name": "DELETE /api/events/:eventoID/schedules/:scheduleID",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:eventoID/schedules/:scheduleID",
+              "raw": "{{dev}}/api/events/:eventoID/schedules/:scheduleID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 ":eventoID",
                 "schedules",
                 ":scheduleID"
@@ -2863,34 +3576,42 @@
           }
         },
         {
-          "name": "PUT /:eventoID/invitations/:usuarioID",
+          "name": "PUT /api/events/:eventoID/invitations/:usuarioID",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:eventoID/invitations/:usuarioID",
+              "raw": "{{dev}}/api/events/:eventoID/invitations/:usuarioID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 ":eventoID",
                 "invitations",
                 ":usuarioID"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /:eventoID/invitations/:usuarioID",
+          "name": "DELETE /api/events/:eventoID/invitations/:usuarioID",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:eventoID/invitations/:usuarioID",
+              "raw": "{{dev}}/api/events/:eventoID/invitations/:usuarioID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 ":eventoID",
                 "invitations",
                 ":usuarioID"
@@ -2899,32 +3620,40 @@
           }
         },
         {
-          "name": "POST /groups",
+          "name": "POST /api/events/groups",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/groups",
+              "raw": "{{dev}}/api/events/groups",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 "groups"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /groups/company/:empresaID",
+          "name": "GET /api/events/groups/company/:empresaID",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/groups/company/:empresaID",
+              "raw": "{{dev}}/api/events/groups/company/:empresaID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 "groups",
                 "company",
                 ":empresaID"
@@ -2933,16 +3662,18 @@
           }
         },
         {
-          "name": "DELETE /groups/:groupID",
+          "name": "DELETE /api/events/groups/:groupID",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/groups/:groupID",
+              "raw": "{{dev}}/api/events/groups/:groupID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 "groups",
                 ":groupID"
               ]
@@ -2950,37 +3681,49 @@
           }
         },
         {
-          "name": "PUT /groups/:groupID",
+          "name": "PUT /api/events/groups/:groupID",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/groups/:groupID",
+              "raw": "{{dev}}/api/events/groups/:groupID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 "groups",
                 ":groupID"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /groups/:groupID/members",
+          "name": "PUT /api/events/groups/:groupID/members",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/groups/:groupID/members",
+              "raw": "{{dev}}/api/events/groups/:groupID/members",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "events",
                 "groups",
                 ":groupID",
                 "members"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -2990,16 +3733,24 @@
       "name": "followers",
       "item": [
         {
-          "name": "POST /",
+          "name": "POST /api/followers/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/followers/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "followers",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -3009,46 +3760,58 @@
       "name": "friends",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/friends/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/friends/",
               "host": [
-                "{{baseUrl}}"
-              ],
-              "path": []
-            }
-          }
-        },
-        {
-          "name": "POST /refuse",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/refuse",
-              "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
-                "refuse"
+                "api",
+                "friends",
+                ""
               ]
             }
           }
         },
         {
-          "name": "GET /check/:myId/:userId",
+          "name": "POST /api/friends/refuse",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{dev}}/api/friends/refuse",
+              "host": [
+                "{{dev}}"
+              ],
+              "path": [
+                "api",
+                "friends",
+                "refuse"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "GET /api/friends/check/:myId/:userId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/check/:myId/:userId",
+              "raw": "{{dev}}/api/friends/check/:myId/:userId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "friends",
                 "check",
                 ":myId",
                 ":userId"
@@ -3062,80 +3825,108 @@
       "name": "hades",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/hades/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/hades/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "hades",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "POST /company-certification",
+          "name": "POST /api/hades/company-certification",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/company-certification",
+              "raw": "{{dev}}/api/hades/company-certification",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "hades",
                 "company-certification"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /company-certification-test",
+          "name": "POST /api/hades/company-certification-test",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/company-certification-test",
+              "raw": "{{dev}}/api/hades/company-certification-test",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "hades",
                 "company-certification-test"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /credit-report",
+          "name": "POST /api/hades/credit-report",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/credit-report",
+              "raw": "{{dev}}/api/hades/credit-report",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "hades",
                 "credit-report"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /credit-report-test",
+          "name": "POST /api/hades/credit-report-test",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/credit-report-test",
+              "raw": "{{dev}}/api/hades/credit-report-test",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "hades",
                 "credit-report-test"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -3145,16 +3936,20 @@
       "name": "industries",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/industries/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/industries/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "industries",
+                ""
+              ]
             }
           }
         }
@@ -3164,16 +3959,24 @@
       "name": "information",
       "item": [
         {
-          "name": "POST /",
+          "name": "POST /api/information/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/information/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "information",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -3183,32 +3986,46 @@
       "name": "invitations",
       "item": [
         {
-          "name": "POST /",
+          "name": "POST /api/invitations/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/invitations/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "invitations",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /signup",
+          "name": "POST /api/invitations/signup",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/signup",
+              "raw": "{{dev}}/api/invitations/signup",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "invitations",
                 "signup"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -3218,32 +4035,40 @@
       "name": "konesh",
       "item": [
         {
-          "name": "POST /ValidaListaService",
+          "name": "POST /api/konesh/ValidaListaService",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/ValidaListaService",
+              "raw": "{{dev}}/api/konesh/ValidaListaService",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "konesh",
                 "ValidaListaService"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /consultaEstatusKonesh/:rfc",
+          "name": "GET /api/konesh/consultaEstatusKonesh/:rfc",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/consultaEstatusKonesh/:rfc",
+              "raw": "{{dev}}/api/konesh/consultaEstatusKonesh/:rfc",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "konesh",
                 "consultaEstatusKonesh",
                 ":rfc"
               ]
@@ -3251,34 +4076,46 @@
           }
         },
         {
-          "name": "POST /descifra",
+          "name": "POST /api/konesh/descifra",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/descifra",
+              "raw": "{{dev}}/api/konesh/descifra",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "konesh",
                 "descifra"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /cifra",
+          "name": "POST /api/konesh/cifra",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/cifra",
+              "raw": "{{dev}}/api/konesh/cifra",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "konesh",
                 "cifra"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -3288,62 +4125,72 @@
       "name": "messages",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/messages/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/messages/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "messages",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /company",
+          "name": "GET /api/messages/company",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/company",
+              "raw": "{{dev}}/api/messages/company",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "messages",
                 "company"
               ]
             }
           }
         },
         {
-          "name": "GET /:roomUUID",
+          "name": "GET /api/messages/:roomUUID",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:roomUUID",
+              "raw": "{{dev}}/api/messages/:roomUUID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "messages",
                 ":roomUUID"
               ]
             }
           }
         },
         {
-          "name": "DELETE /:roomUUID/:messageUUID/:userID",
+          "name": "DELETE /api/messages/:roomUUID/:messageUUID/:userID",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:roomUUID/:messageUUID/:userID",
+              "raw": "{{dev}}/api/messages/:roomUUID/:messageUUID/:userID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "messages",
                 ":roomUUID",
                 ":messageUUID",
                 ":userID"
@@ -3352,49 +4199,69 @@
           }
         },
         {
-          "name": "PUT /:roomUUID/messages",
+          "name": "PUT /api/messages/:roomUUID/messages",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:roomUUID/messages",
+              "raw": "{{dev}}/api/messages/:roomUUID/messages",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "messages",
                 ":roomUUID",
                 "messages"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /",
+          "name": "POST /api/messages/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/messages/",
               "host": [
-                "{{baseUrl}}"
-              ],
-              "path": []
-            }
-          }
-        },
-        {
-          "name": "POST /message",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/message",
-              "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "messages",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "POST /api/messages/message",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{dev}}/api/messages/message",
+              "host": [
+                "{{dev}}"
+              ],
+              "path": [
+                "api",
+                "messages",
                 "message"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -3404,16 +4271,20 @@
       "name": "metadata",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/metadata/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/metadata/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "metadata",
+                ""
+              ]
             }
           }
         }
@@ -3423,16 +4294,20 @@
       "name": "money-exchange",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/money-exchange/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/money-exchange/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "money-exchange",
+                ""
+              ]
             }
           }
         }
@@ -3442,78 +4317,100 @@
       "name": "notifications",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/notifications/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/notifications/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "notifications",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /:user",
+          "name": "GET /api/notifications/:user",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:user",
+              "raw": "{{dev}}/api/notifications/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "notifications",
                 ":user"
               ]
             }
           }
         },
         {
-          "name": "POST /",
+          "name": "POST /api/notifications/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/notifications/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "notifications",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /:uuid",
+          "name": "DELETE /api/notifications/:uuid",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:uuid",
+              "raw": "{{dev}}/api/notifications/:uuid",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "notifications",
                 ":uuid"
               ]
             }
           }
         },
         {
-          "name": "PUT /:uuid",
+          "name": "PUT /api/notifications/:uuid",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:uuid",
+              "raw": "{{dev}}/api/notifications/:uuid",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "notifications",
                 ":uuid"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -3523,30 +4420,36 @@
       "name": "payments",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/payments/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/payments/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "payments",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /:user/intent",
+          "name": "GET /api/payments/:user/intent",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:user/intent",
+              "raw": "{{dev}}/api/payments/:user/intent",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "payments",
                 ":user",
                 "intent"
               ]
@@ -3554,49 +4457,63 @@
           }
         },
         {
-          "name": "POST /:user",
+          "name": "POST /api/payments/:user",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:user",
+              "raw": "{{dev}}/api/payments/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "payments",
                 ":user"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /:user/card",
+          "name": "POST /api/payments/:user/card",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:user/card",
+              "raw": "{{dev}}/api/payments/:user/card",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "payments",
                 ":user",
                 "card"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /:user/card",
+          "name": "GET /api/payments/:user/card",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:user/card",
+              "raw": "{{dev}}/api/payments/:user/card",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "payments",
                 ":user",
                 "card"
               ]
@@ -3604,16 +4521,18 @@
           }
         },
         {
-          "name": "DELETE /:user/card/:card",
+          "name": "DELETE /api/payments/:user/card/:card",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:user/card/:card",
+              "raw": "{{dev}}/api/payments/:user/card/:card",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "payments",
                 ":user",
                 "card",
                 ":card"
@@ -3622,16 +4541,18 @@
           }
         },
         {
-          "name": "GET /:companyID/payments",
+          "name": "GET /api/payments/:companyID/payments",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:companyID/payments",
+              "raw": "{{dev}}/api/payments/:companyID/payments",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "payments",
                 ":companyID",
                 "payments"
               ]
@@ -3644,62 +4565,72 @@
       "name": "productos",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/productos/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/productos/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "productos",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /categorias",
+          "name": "GET /api/productos/categorias",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/categorias",
+              "raw": "{{dev}}/api/productos/categorias",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 "categorias"
               ]
             }
           }
         },
         {
-          "name": "GET /:productId",
+          "name": "GET /api/productos/:productId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:productId",
+              "raw": "{{dev}}/api/productos/:productId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 ":productId"
               ]
             }
           }
         },
         {
-          "name": "GET /web/:productId",
+          "name": "GET /api/productos/web/:productId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/web/:productId",
+              "raw": "{{dev}}/api/productos/web/:productId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 "web",
                 ":productId"
               ]
@@ -3707,66 +4638,86 @@
           }
         },
         {
-          "name": "POST /search",
+          "name": "POST /api/productos/search",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/search",
+              "raw": "{{dev}}/api/productos/search",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 "search"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /comentar/:productoID",
+          "name": "POST /api/productos/comentar/:productoID",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentar/:productoID",
+              "raw": "{{dev}}/api/productos/comentar/:productoID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 "comentar",
                 ":productoID"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /comentar/:id",
+          "name": "PUT /api/productos/comentar/:id",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentar/:id",
+              "raw": "{{dev}}/api/productos/comentar/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 "comentar",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /comentar/:id",
+          "name": "DELETE /api/productos/comentar/:id",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentar/:id",
+              "raw": "{{dev}}/api/productos/comentar/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 "comentar",
                 ":id"
               ]
@@ -3774,34 +4725,46 @@
           }
         },
         {
-          "name": "PUT /categorias",
+          "name": "PUT /api/productos/categorias",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/categorias",
+              "raw": "{{dev}}/api/productos/categorias",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 "categorias"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /reviews",
+          "name": "POST /api/productos/reviews",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reviews",
+              "raw": "{{dev}}/api/productos/reviews",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "productos",
                 "reviews"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -3811,160 +4774,216 @@
       "name": "publicaciones",
       "item": [
         {
-          "name": "POST /crearPublicacion",
+          "name": "POST /api/publicaciones/crearPublicacion",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/crearPublicacion",
+              "raw": "{{dev}}/api/publicaciones/crearPublicacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "crearPublicacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /editarPublicacion",
+          "name": "PUT /api/publicaciones/editarPublicacion",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/editarPublicacion",
+              "raw": "{{dev}}/api/publicaciones/editarPublicacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "editarPublicacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /uploadImageGaleriaPublicacion",
+          "name": "POST /api/publicaciones/uploadImageGaleriaPublicacion",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/uploadImageGaleriaPublicacion",
+              "raw": "{{dev}}/api/publicaciones/uploadImageGaleriaPublicacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "uploadImageGaleriaPublicacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /crearComentario",
+          "name": "POST /api/publicaciones/crearComentario",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/crearComentario",
+              "raw": "{{dev}}/api/publicaciones/crearComentario",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "crearComentario"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /editarComentario",
+          "name": "PUT /api/publicaciones/editarComentario",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/editarComentario",
+              "raw": "{{dev}}/api/publicaciones/editarComentario",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "editarComentario"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /likePublicacion",
+          "name": "POST /api/publicaciones/likePublicacion",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/likePublicacion",
+              "raw": "{{dev}}/api/publicaciones/likePublicacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "likePublicacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /disLikePublicacion",
+          "name": "POST /api/publicaciones/disLikePublicacion",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/disLikePublicacion",
+              "raw": "{{dev}}/api/publicaciones/disLikePublicacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "disLikePublicacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /likeComentario",
+          "name": "POST /api/publicaciones/likeComentario",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/likeComentario",
+              "raw": "{{dev}}/api/publicaciones/likeComentario",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "likeComentario"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /disLikeComentario",
+          "name": "POST /api/publicaciones/disLikeComentario",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/disLikeComentario",
+              "raw": "{{dev}}/api/publicaciones/disLikeComentario",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "disLikeComentario"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getPublicaciones/:id_empresa/:id_usuario",
+          "name": "GET /api/publicaciones/getPublicaciones/:id_empresa/:id_usuario",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPublicaciones/:id_empresa/:id_usuario",
+              "raw": "{{dev}}/api/publicaciones/getPublicaciones/:id_empresa/:id_usuario",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "getPublicaciones",
                 ":id_empresa",
                 ":id_usuario"
@@ -3973,16 +4992,18 @@
           }
         },
         {
-          "name": "GET /getComentarios/:id_publicacion",
+          "name": "GET /api/publicaciones/getComentarios/:id_publicacion",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getComentarios/:id_publicacion",
+              "raw": "{{dev}}/api/publicaciones/getComentarios/:id_publicacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "getComentarios",
                 ":id_publicacion"
               ]
@@ -3990,16 +5011,18 @@
           }
         },
         {
-          "name": "DELETE /eliminarPublicacion/:id_publicacion",
+          "name": "DELETE /api/publicaciones/eliminarPublicacion/:id_publicacion",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/eliminarPublicacion/:id_publicacion",
+              "raw": "{{dev}}/api/publicaciones/eliminarPublicacion/:id_publicacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "eliminarPublicacion",
                 ":id_publicacion"
               ]
@@ -4007,124 +5030,164 @@
           }
         },
         {
-          "name": "POST /",
+          "name": "POST /api/publicaciones/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/publicaciones/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "publicaciones",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /",
+          "name": "GET /api/publicaciones/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/publicaciones/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "publicaciones",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "POST /uploadVideCorporativo",
+          "name": "POST /api/publicaciones/uploadVideCorporativo",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/uploadVideCorporativo",
+              "raw": "{{dev}}/api/publicaciones/uploadVideCorporativo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "uploadVideCorporativo"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /uploadBannerCorporativo",
+          "name": "POST /api/publicaciones/uploadBannerCorporativo",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/uploadBannerCorporativo",
+              "raw": "{{dev}}/api/publicaciones/uploadBannerCorporativo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "uploadBannerCorporativo"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /uploadLogoCorporativo",
+          "name": "POST /api/publicaciones/uploadLogoCorporativo",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/uploadLogoCorporativo",
+              "raw": "{{dev}}/api/publicaciones/uploadLogoCorporativo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "uploadLogoCorporativo"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /:publicationId",
+          "name": "PUT /api/publicaciones/:publicationId",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:publicationId",
+              "raw": "{{dev}}/api/publicaciones/:publicationId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 ":publicationId"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /:publicationId",
+          "name": "DELETE /api/publicaciones/:publicationId",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:publicationId",
+              "raw": "{{dev}}/api/publicaciones/:publicationId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 ":publicationId"
               ]
             }
           }
         },
         {
-          "name": "GET /red/:usuario",
+          "name": "GET /api/publicaciones/red/:usuario",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/red/:usuario",
+              "raw": "{{dev}}/api/publicaciones/red/:usuario",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "red",
                 ":usuario"
               ]
@@ -4132,16 +5195,18 @@
           }
         },
         {
-          "name": "GET /usuario/:usuario",
+          "name": "GET /api/publicaciones/usuario/:usuario",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/usuario/:usuario",
+              "raw": "{{dev}}/api/publicaciones/usuario/:usuario",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "usuario",
                 ":usuario"
               ]
@@ -4149,16 +5214,18 @@
           }
         },
         {
-          "name": "GET /comentarios/:publicationId",
+          "name": "GET /api/publicaciones/comentarios/:publicationId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios/:publicationId",
+              "raw": "{{dev}}/api/publicaciones/comentarios/:publicationId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "comentarios",
                 ":publicationId"
               ]
@@ -4166,50 +5233,64 @@
           }
         },
         {
-          "name": "POST /comentarios/:id",
+          "name": "POST /api/publicaciones/comentarios/:id",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios/:id",
+              "raw": "{{dev}}/api/publicaciones/comentarios/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "comentarios",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /comentarios/:id",
+          "name": "PUT /api/publicaciones/comentarios/:id",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios/:id",
+              "raw": "{{dev}}/api/publicaciones/comentarios/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "comentarios",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /comentarios/:id",
+          "name": "DELETE /api/publicaciones/comentarios/:id",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/comentarios/:id",
+              "raw": "{{dev}}/api/publicaciones/comentarios/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "comentarios",
                 ":id"
               ]
@@ -4217,82 +5298,108 @@
           }
         },
         {
-          "name": "POST /like",
+          "name": "POST /api/publicaciones/like",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/like",
+              "raw": "{{dev}}/api/publicaciones/like",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "like"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /like/comment",
+          "name": "POST /api/publicaciones/like/comment",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/like/comment",
+              "raw": "{{dev}}/api/publicaciones/like/comment",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "like",
                 "comment"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /subcomentarios",
+          "name": "POST /api/publicaciones/subcomentarios",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/subcomentarios",
+              "raw": "{{dev}}/api/publicaciones/subcomentarios",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "subcomentarios"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /subcomentarios/:uuid",
+          "name": "PUT /api/publicaciones/subcomentarios/:uuid",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/subcomentarios/:uuid",
+              "raw": "{{dev}}/api/publicaciones/subcomentarios/:uuid",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "subcomentarios",
                 ":uuid"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "DELETE /subcomentarios/:uuid",
+          "name": "DELETE /api/publicaciones/subcomentarios/:uuid",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/subcomentarios/:uuid",
+              "raw": "{{dev}}/api/publicaciones/subcomentarios/:uuid",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "subcomentarios",
                 ":uuid"
               ]
@@ -4300,34 +5407,42 @@
           }
         },
         {
-          "name": "POST /subcomentarios/:uuid/like",
+          "name": "POST /api/publicaciones/subcomentarios/:uuid/like",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/subcomentarios/:uuid/like",
+              "raw": "{{dev}}/api/publicaciones/subcomentarios/:uuid/like",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "subcomentarios",
                 ":uuid",
                 "like"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /empresa/:companyID",
+          "name": "GET /api/publicaciones/empresa/:companyID",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/empresa/:companyID",
+              "raw": "{{dev}}/api/publicaciones/empresa/:companyID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "empresa",
                 ":companyID"
               ]
@@ -4335,16 +5450,18 @@
           }
         },
         {
-          "name": "GET /publicas/ultimas",
+          "name": "GET /api/publicaciones/publicas/ultimas",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/publicas/ultimas",
+              "raw": "{{dev}}/api/publicaciones/publicas/ultimas",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 "publicas",
                 "ultimas"
               ]
@@ -4352,16 +5469,18 @@
           }
         },
         {
-          "name": "GET /:usuID/:pubID",
+          "name": "GET /api/publicaciones/:usuID/:pubID",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:usuID/:pubID",
+              "raw": "{{dev}}/api/publicaciones/:usuID/:pubID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "publicaciones",
                 ":usuID",
                 ":pubID"
               ]
@@ -4374,30 +5493,36 @@
       "name": "quotes",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/quotes/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/quotes/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "quotes",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /user/:user",
+          "name": "GET /api/quotes/user/:user",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/user/:user",
+              "raw": "{{dev}}/api/quotes/user/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "quotes",
                 "user",
                 ":user"
               ]
@@ -4405,16 +5530,18 @@
           }
         },
         {
-          "name": "GET /user/:user/check",
+          "name": "GET /api/quotes/user/:user/check",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/user/:user/check",
+              "raw": "{{dev}}/api/quotes/user/:user/check",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "quotes",
                 "user",
                 ":user",
                 "check"
@@ -4428,78 +5555,90 @@
       "name": "search",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/search/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/search/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "search",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /suggestions",
+          "name": "GET /api/search/suggestions",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/suggestions",
+              "raw": "{{dev}}/api/search/suggestions",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "search",
                 "suggestions"
               ]
             }
           }
         },
         {
-          "name": "GET /sugerenciasBusqueda",
+          "name": "GET /api/search/sugerenciasBusqueda",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/sugerenciasBusqueda",
+              "raw": "{{dev}}/api/search/sugerenciasBusqueda",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "search",
                 "sugerenciasBusqueda"
               ]
             }
           }
         },
         {
-          "name": "GET /category",
+          "name": "GET /api/search/category",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/category",
+              "raw": "{{dev}}/api/search/category",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "search",
                 "category"
               ]
             }
           }
         },
         {
-          "name": "GET /taxId/:taxId",
+          "name": "GET /api/search/taxId/:taxId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/taxId/:taxId",
+              "raw": "{{dev}}/api/search/taxId/:taxId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "search",
                 "taxId",
                 ":taxId"
               ]
@@ -4507,16 +5646,18 @@
           }
         },
         {
-          "name": "GET /taxIdComplete/:taxId",
+          "name": "GET /api/search/taxIdComplete/:taxId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/taxIdComplete/:taxId",
+              "raw": "{{dev}}/api/search/taxIdComplete/:taxId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "search",
                 "taxIdComplete",
                 ":taxId"
               ]
@@ -4524,16 +5665,18 @@
           }
         },
         {
-          "name": "GET /buscador",
+          "name": "GET /api/search/buscador",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/buscador",
+              "raw": "{{dev}}/api/search/buscador",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "search",
                 "buscador"
               ]
             }
@@ -4545,30 +5688,36 @@
       "name": "sitemap",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/sitemap/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/sitemap/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "sitemap",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /sub",
+          "name": "GET /api/sitemap/sub",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/sub",
+              "raw": "{{dev}}/api/sitemap/sub",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "sitemap",
                 "sub"
               ]
             }
@@ -4580,30 +5729,40 @@
       "name": "solicitud-credito",
       "item": [
         {
-          "name": "POST /",
+          "name": "POST /api/solicitud-credito/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/solicitud-credito/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "solicitud-credito",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /saldo/:idEmpresa",
+          "name": "GET /api/solicitud-credito/saldo/:idEmpresa",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/saldo/:idEmpresa",
+              "raw": "{{dev}}/api/solicitud-credito/saldo/:idEmpresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "saldo",
                 ":idEmpresa"
               ]
@@ -4611,80 +5770,106 @@
           }
         },
         {
-          "name": "POST /agregar",
+          "name": "POST /api/solicitud-credito/agregar",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/agregar",
+              "raw": "{{dev}}/api/solicitud-credito/agregar",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "agregar"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /actualizar",
+          "name": "POST /api/solicitud-credito/actualizar",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/actualizar",
+              "raw": "{{dev}}/api/solicitud-credito/actualizar",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "actualizar"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /reintegrar",
+          "name": "POST /api/solicitud-credito/reintegrar",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reintegrar",
+              "raw": "{{dev}}/api/solicitud-credito/reintegrar",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "reintegrar"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /restar",
+          "name": "POST /api/solicitud-credito/restar",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/restar",
+              "raw": "{{dev}}/api/solicitud-credito/restar",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "restar"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getCodigos/:idEmpresa",
+          "name": "GET /api/solicitud-credito/getCodigos/:idEmpresa",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getCodigos/:idEmpresa",
+              "raw": "{{dev}}/api/solicitud-credito/getCodigos/:idEmpresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "getCodigos",
                 ":idEmpresa"
               ]
@@ -4692,49 +5877,60 @@
           }
         },
         {
-          "name": "POST /asignar_codigo",
+          "name": "POST /api/solicitud-credito/asignar_codigo",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/asignar_codigo",
+              "raw": "{{dev}}/api/solicitud-credito/asignar_codigo",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "asignar_codigo"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /enviadas/:idEmpresa/",
+          "name": "GET /api/solicitud-credito/enviadas/:idEmpresa/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/enviadas/:idEmpresa/",
+              "raw": "{{dev}}/api/solicitud-credito/enviadas/:idEmpresa/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "enviadas",
-                ":idEmpresa"
+                ":idEmpresa",
+                ""
               ]
             }
           }
         },
         {
-          "name": "GET /recibidas/:idEmpresa",
+          "name": "GET /api/solicitud-credito/recibidas/:idEmpresa",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/recibidas/:idEmpresa",
+              "raw": "{{dev}}/api/solicitud-credito/recibidas/:idEmpresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "recibidas",
                 ":idEmpresa"
               ]
@@ -4742,50 +5938,68 @@
           }
         },
         {
-          "name": "POST /invitacion",
+          "name": "POST /api/solicitud-credito/invitacion",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/invitacion",
+              "raw": "{{dev}}/api/solicitud-credito/invitacion",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "invitacion"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /reenviar-solicitud",
+          "name": "POST /api/solicitud-credito/reenviar-solicitud",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reenviar-solicitud",
+              "raw": "{{dev}}/api/solicitud-credito/reenviar-solicitud",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "reenviar-solicitud"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /reenviar-solicitud-interna",
+          "name": "POST /api/solicitud-credito/reenviar-solicitud-interna",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/reenviar-solicitud-interna",
+              "raw": "{{dev}}/api/solicitud-credito/reenviar-solicitud-interna",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "solicitud-credito",
                 "reenviar-solicitud-interna"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -4795,16 +6009,18 @@
       "name": "statistics",
       "item": [
         {
-          "name": "GET /company/:empresa",
+          "name": "GET /api/statistics/company/:empresa",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/company/:empresa",
+              "raw": "{{dev}}/api/statistics/company/:empresa",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "statistics",
                 "company",
                 ":empresa"
               ]
@@ -4812,16 +6028,18 @@
           }
         },
         {
-          "name": "GET /user/:user",
+          "name": "GET /api/statistics/user/:user",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/user/:user",
+              "raw": "{{dev}}/api/statistics/user/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "statistics",
                 "user",
                 ":user"
               ]
@@ -4829,32 +6047,36 @@
           }
         },
         {
-          "name": "GET /homepage",
+          "name": "GET /api/statistics/homepage",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/homepage",
+              "raw": "{{dev}}/api/statistics/homepage",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "statistics",
                 "homepage"
               ]
             }
           }
         },
         {
-          "name": "GET /numbers/:user",
+          "name": "GET /api/statistics/numbers/:user",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/numbers/:user",
+              "raw": "{{dev}}/api/statistics/numbers/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "statistics",
                 "numbers",
                 ":user"
               ]
@@ -4862,36 +6084,48 @@
           }
         },
         {
-          "name": "POST /numbers/:user",
+          "name": "POST /api/statistics/numbers/:user",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/numbers/:user",
+              "raw": "{{dev}}/api/statistics/numbers/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "statistics",
                 "numbers",
                 ":user"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /numbers/:user",
+          "name": "PUT /api/statistics/numbers/:user",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/numbers/:user",
+              "raw": "{{dev}}/api/statistics/numbers/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "statistics",
                 "numbers",
                 ":user"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -4901,50 +6135,68 @@
       "name": "stripe",
       "item": [
         {
-          "name": "POST /pagar",
+          "name": "POST /api/stripe/pagar",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/pagar",
+              "raw": "{{dev}}/api/stripe/pagar",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "stripe",
                 "pagar"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /confirmarPago",
+          "name": "POST /api/stripe/confirmarPago",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/confirmarPago",
+              "raw": "{{dev}}/api/stripe/confirmarPago",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "stripe",
                 "confirmarPago"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /cancelarPago",
+          "name": "POST /api/stripe/cancelarPago",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/cancelarPago",
+              "raw": "{{dev}}/api/stripe/cancelarPago",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "stripe",
                 "cancelarPago"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -4954,48 +6206,64 @@
       "name": "support",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/support/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/support/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "support",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "POST /suggestions",
+          "name": "POST /api/support/suggestions",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/suggestions",
+              "raw": "{{dev}}/api/support/suggestions",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "support",
                 "suggestions"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /problems",
+          "name": "POST /api/support/problems",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/problems",
+              "raw": "{{dev}}/api/support/problems",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "support",
                 "problems"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -5005,30 +6273,40 @@
       "name": "tokens",
       "item": [
         {
-          "name": "POST /",
+          "name": "POST /api/tokens/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/tokens/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "tokens",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /user/:user",
+          "name": "GET /api/tokens/user/:user",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/user/:user",
+              "raw": "{{dev}}/api/tokens/user/:user",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "tokens",
                 "user",
                 ":user"
               ]
@@ -5036,16 +6314,18 @@
           }
         },
         {
-          "name": "DELETE /token/:token/:type",
+          "name": "DELETE /api/tokens/token/:token/:type",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/token/:token/:type",
+              "raw": "{{dev}}/api/tokens/token/:token/:type",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "tokens",
                 "token",
                 ":token",
                 ":type"
@@ -5054,16 +6334,18 @@
           }
         },
         {
-          "name": "GET /companies",
+          "name": "GET /api/tokens/companies",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/companies",
+              "raw": "{{dev}}/api/tokens/companies",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "tokens",
                 "companies"
               ]
             }
@@ -5075,30 +6357,36 @@
       "name": "trade-names",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/trade-names/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/trade-names/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "trade-names",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "DELETE /:tradeId",
+          "name": "DELETE /api/trade-names/:tradeId",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:tradeId",
+              "raw": "{{dev}}/api/trade-names/:tradeId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "trade-names",
                 ":tradeId"
               ]
             }
@@ -5110,16 +6398,20 @@
       "name": "units",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/units/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/units/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "units",
+                ""
+              ]
             }
           }
         }
@@ -5129,46 +6421,54 @@
       "name": "usuarios",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/usuarios/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/usuarios/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "usuarios",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "GET /:userId",
+          "name": "GET /api/usuarios/:userId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:userId",
+              "raw": "{{dev}}/api/usuarios/:userId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 ":userId"
               ]
             }
           }
         },
         {
-          "name": "GET /verificarActualizacion/:userId",
+          "name": "GET /api/usuarios/verificarActualizacion/:userId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/verificarActualizacion/:userId",
+              "raw": "{{dev}}/api/usuarios/verificarActualizacion/:userId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "verificarActualizacion",
                 ":userId"
               ]
@@ -5176,145 +6476,197 @@
           }
         },
         {
-          "name": "POST /",
+          "name": "POST /api/usuarios/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/usuarios/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "usuarios",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /verificar/reenviar",
+          "name": "POST /api/usuarios/verificar/reenviar",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/verificar/reenviar",
+              "raw": "{{dev}}/api/usuarios/verificar/reenviar",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "verificar",
                 "reenviar"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /verificar",
+          "name": "POST /api/usuarios/verificar",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/verificar",
+              "raw": "{{dev}}/api/usuarios/verificar",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "verificar"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /:userID",
+          "name": "PUT /api/usuarios/:userID",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/:userID",
+              "raw": "{{dev}}/api/usuarios/:userID",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 ":userID"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /registro-caducidad",
+          "name": "POST /api/usuarios/registro-caducidad",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/registro-caducidad",
+              "raw": "{{dev}}/api/usuarios/registro-caducidad",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "registro-caducidad"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /request-password",
+          "name": "POST /api/usuarios/request-password",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/request-password",
+              "raw": "{{dev}}/api/usuarios/request-password",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "request-password"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /change-password/:token",
+          "name": "POST /api/usuarios/change-password/:token",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/change-password/:token",
+              "raw": "{{dev}}/api/usuarios/change-password/:token",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "change-password",
                 ":token"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /admins/:usrId",
+          "name": "PUT /api/usuarios/admins/:usrId",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/admins/:usrId",
+              "raw": "{{dev}}/api/usuarios/admins/:usrId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "admins",
                 ":usrId"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /byId/:userId",
+          "name": "GET /api/usuarios/byId/:userId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/byId/:userId",
+              "raw": "{{dev}}/api/usuarios/byId/:userId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "byId",
                 ":userId"
               ]
@@ -5322,32 +6674,40 @@
           }
         },
         {
-          "name": "POST /registerWithInvitation",
+          "name": "POST /api/usuarios/registerWithInvitation",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/registerWithInvitation",
+              "raw": "{{dev}}/api/usuarios/registerWithInvitation",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "registerWithInvitation"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /byIdCompanie/:id_companie",
+          "name": "GET /api/usuarios/byIdCompanie/:id_companie",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/byIdCompanie/:id_companie",
+              "raw": "{{dev}}/api/usuarios/byIdCompanie/:id_companie",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "byIdCompanie",
                 ":id_companie"
               ]
@@ -5355,16 +6715,18 @@
           }
         },
         {
-          "name": "GET /getPermisos/:userId",
+          "name": "GET /api/usuarios/getPermisos/:userId",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPermisos/:userId",
+              "raw": "{{dev}}/api/usuarios/getPermisos/:userId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "getPermisos",
                 ":userId"
               ]
@@ -5372,16 +6734,18 @@
           }
         },
         {
-          "name": "GET /catalogo/getPermisos",
+          "name": "GET /api/usuarios/catalogo/getPermisos",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/catalogo/getPermisos",
+              "raw": "{{dev}}/api/usuarios/catalogo/getPermisos",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "catalogo",
                 "getPermisos"
               ]
@@ -5389,32 +6753,40 @@
           }
         },
         {
-          "name": "POST /createPerfilPermisos",
+          "name": "POST /api/usuarios/createPerfilPermisos",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/createPerfilPermisos",
+              "raw": "{{dev}}/api/usuarios/createPerfilPermisos",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "createPerfilPermisos"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "GET /getPerfilesPermisosByEmpresa/:emp_id",
+          "name": "GET /api/usuarios/getPerfilesPermisosByEmpresa/:emp_id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/getPerfilesPermisosByEmpresa/:emp_id",
+              "raw": "{{dev}}/api/usuarios/getPerfilesPermisosByEmpresa/:emp_id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "getPerfilesPermisosByEmpresa",
                 ":emp_id"
               ]
@@ -5422,36 +6794,48 @@
           }
         },
         {
-          "name": "PUT /updatePermisos/:userId",
+          "name": "PUT /api/usuarios/updatePermisos/:userId",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/updatePermisos/:userId",
+              "raw": "{{dev}}/api/usuarios/updatePermisos/:userId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "updatePermisos",
                 ":userId"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /updatePerfilPermisos/:id",
+          "name": "PUT /api/usuarios/updatePerfilPermisos/:id",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/updatePerfilPermisos/:id",
+              "raw": "{{dev}}/api/usuarios/updatePerfilPermisos/:id",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "usuarios",
                 "updatePerfilPermisos",
                 ":id"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -5461,98 +6845,132 @@
       "name": "validation",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/validation/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/validation/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "validation",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "POST /sendEmail",
+          "name": "POST /api/validation/sendEmail",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/sendEmail",
+              "raw": "{{dev}}/api/validation/sendEmail",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "validation",
                 "sendEmail"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /sendEmailTemplateRegister",
+          "name": "POST /api/validation/sendEmailTemplateRegister",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/sendEmailTemplateRegister",
+              "raw": "{{dev}}/api/validation/sendEmailTemplateRegister",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "validation",
                 "sendEmailTemplateRegister"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /validaToken/:token/:userId",
+          "name": "PUT /api/validation/validaToken/:token/:userId",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/validaToken/:token/:userId",
+              "raw": "{{dev}}/api/validation/validaToken/:token/:userId",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "validation",
                 "validaToken",
                 ":token",
                 ":userId"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "PUT /estatusRegistro",
+          "name": "PUT /api/validation/estatusRegistro",
           "request": {
             "method": "PUT",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/estatusRegistro",
+              "raw": "{{dev}}/api/validation/estatusRegistro",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "validation",
                 "estatusRegistro"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         },
         {
-          "name": "POST /sendEmailTemplate",
+          "name": "POST /api/validation/sendEmailTemplate",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/sendEmailTemplate",
+              "raw": "{{dev}}/api/validation/sendEmailTemplate",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
               "path": [
+                "api",
+                "validation",
                 "sendEmailTemplate"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -5562,16 +6980,24 @@
       "name": "videos",
       "item": [
         {
-          "name": "POST /",
+          "name": "POST /api/videos/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/videos/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "videos",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -5581,30 +7007,42 @@
       "name": "visits",
       "item": [
         {
-          "name": "GET /",
+          "name": "GET /api/visits/",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/visits/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "visits",
+                ""
+              ]
             }
           }
         },
         {
-          "name": "POST /",
+          "name": "POST /api/visits/",
           "request": {
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/",
+              "raw": "{{dev}}/api/visits/",
               "host": [
-                "{{baseUrl}}"
+                "{{dev}}"
               ],
-              "path": []
+              "path": [
+                "api",
+                "visits",
+                ""
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
             }
           }
         }
@@ -5613,7 +7051,7 @@
   ],
   "variable": [
     {
-      "key": "baseUrl",
+      "key": "dev",
       "value": "http://localhost:3000"
     }
   ]


### PR DESCRIPTION
## Summary
- update postman generator to use `{{dev}}` variable
- include `/api/<route>` prefix when building URLs
- set a basic raw body for POST/PUT/PATCH endpoints
- regenerate collection with the new format

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684cc6236404832d9851a96467ce0f30