### PR TITLE
Add dynamic country list to algorithm summary

### DIFF
--- a/postman_collection.json
+++ b/postman_collection.json
@@ -28,6 +28,24 @@
               "raw": "{}"
             }
           }
+        },
+        {
+          "name": "GET /api/algorithm/summary",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{dev}}/api/algorithm/summary",
+              "host": [
+                "{{dev}}"
+              ],
+              "path": [
+                "api",
+                "algorithm",
+                "summary"
+              ]
+            }
+          }
         }
       ]
     },

--- a/src/controllers/api/algorithm.js
+++ b/src/controllers/api/algorithm.js
@@ -41,6 +41,22 @@ const getAlgorithmResult = async (req, res, next) => {
   }
 }
 
+const getAlgorithmSummary = async (req, res, next) => {
+  const fileMethod = 'file: src/controllers/api/algorithm.js - method: getAlgorithmSummary'
+  try {
+    const resumenValores = await algorithmService.getGeneralSummary()
+
+    return res.json({
+      error: false,
+      resumenValores
+    })
+  } catch (error) {
+    logger.error(`${fileMethod} | ${error.message}`)
+    next(error)
+  }
+}
+
 module.exports = {
-  getAlgorithmResult
+  getAlgorithmResult,
+  getAlgorithmSummary
 }

--- a/src/routes/api/algorithm.js
+++ b/src/routes/api/algorithm.js
@@ -7,4 +7,15 @@ const algorithmController = require('../../controllers/api/algorithm')
 
 router.post('/result', algorithmController.getAlgorithmResult)
 
+/**
+ * @swagger
+ * /api/algorithm/summary:
+ *   get:
+ *     summary: Obtiene un resumen de los valores usados en el algoritmo
+ *     responses:
+ *       200:
+ *         description: Resumen generado
+ */
+router.get('/summary', algorithmController.getAlgorithmSummary)
+
 module.exports = router

--- a/src/services/algorithm.js
+++ b/src/services/algorithm.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const mysqlLib = require('../lib/db')
+const certificationService = require('./certification')
 
 class AlgorithmService {
   async getLastCertificationId (clientId) {
@@ -52,6 +53,43 @@ class AlgorithmService {
     `
     const { result } = await mysqlLib.query(query)
     return result[0]
+  }
+
+  async getCapitalContableScore (id_certification) {
+    const capital = await certificationService.capitalContableEBPA(id_certification)
+    if (!capital || capital.capital_contable == null) return null
+    const scoreRow = await certificationService.getScoreCapitalContableEBPA(parseFloat(capital.capital_contable))
+    return scoreRow ? scoreRow.valor_algoritmo : null
+  }
+
+  /**
+   * Return the generic score configuration for the 16 algorithm variables.
+   * These values are not tied to any particular certification.
+   */
+  async getGeneralSummary () {
+    const paises = await certificationService.getPaisesAlgoritmo()
+    const paisScore = Array.isArray(paises.result)
+      ? paises.result.map(p => ({ nombre: p.nombre, score: p.valor_algoritmo }))
+      : []
+
+    return {
+      paisScore,
+      sectorRiesgoScore: { v1: 'valor_algoritmo_sector_riesgo', v2: 'valor_algoritmo_sector_riesgo' },
+      capitalContableScore: { v1: 'score_capital_contable', v2: '0' },
+      plantillaLaboralScore: { v1: 'score_plantilla_laboral', v2: 'score_plantilla_laboral' },
+      sectorClienteFinalScore: { v1: 'valor_algoritmo_sector_cliente_final', v2: 'valor_algoritmo_sector_cliente_final' },
+      tiempoActividadScore: { v1: 'valor_algoritmo_tiempo_actividad', v2: 'valor_algoritmo_tiempo_actividad' },
+      influenciaControlanteScore: { v1: '0', v2: '0' },
+      ventasAnualesScore: { v1: 'score_ventas_anuales', v2: '0' },
+      tipoCifrasScore: { v1: 'score_tipo_cifras', v2: '0' },
+      incidenciasLegalesScore: { v1: 'score_incidencias_legales', v2: 'score_incidencias_legales' },
+      evolucionVentasScore: { v1: 'score_evolucion_ventas', v2: '0' },
+      apalancamientoScore: { v1: 'score_apalancamiento', v2: '0' },
+      flujoNetoScore: { v1: 'score_flujo_neto', v2: '0' },
+      paybackScore: { v1: 'score_payback', v2: '0' },
+      rotacionCtasXCobrarScore: { v1: 'score_rotacion_ctas_x_cobrar', v2: '0' },
+      referenciasProveedoresScore: { v1: 'score_referencias_proveedores', v2: 'score_referencias_proveedores' }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- fetch full country score list for the summary endpoint
- adjust controller to await the updated service

## Testing
- `node generate_postman.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dc8fb09e4832d87074a8ac61f2a51