### PR TITLE
Provide actual algorithm configuration values

### DIFF
--- a/postman_collection.json
+++ b/postman_collection.json
@@ -28,6 +28,43 @@
               "raw": "{}"
             }
           }
+        },
+        {
+          "name": "GET /api/algorithm/summary",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{dev}}/api/algorithm/summary",
+              "host": [
+                "{{dev}}"
+              ],
+              "path": [
+                "api",
+                "algorithm",
+                "summary"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET /api/algorithm/summary/pdf",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{dev}}/api/algorithm/summary/pdf",
+              "host": [
+                "{{dev}}"
+              ],
+              "path": [
+                "api",
+                "algorithm",
+                "summary",
+                "pdf"
+              ]
+            }
+          }
         }
       ]
     },

--- a/src/controllers/api/algorithm.js
+++ b/src/controllers/api/algorithm.js
@@ -1,6 +1,10 @@
 'use strict'
 
 const boom = require('boom')
+const path = require('path')
+const ejs = require('ejs')
+const fsp = require('fs').promises
+const html_to_pdf = require('html-pdf-node')
 const algorithmService = require('../../services/algorithm')
 const logger = require('../../utils/logs/logger')
 
@@ -41,6 +45,51 @@ const getAlgorithmResult = async (req, res, next) => {
   }
 }
 
+const getAlgorithmSummary = async (req, res, next) => {
+  const fileMethod = 'file: src/controllers/api/algorithm.js - method: getAlgorithmSummary'
+  try {
+    const resumenValores = await algorithmService.getGeneralSummary()
+
+    return res.json({
+      error: false,
+      resumenValores
+    })
+  } catch (error) {
+    logger.error(`${fileMethod} | ${error.message}`)
+    next(error)
+  }
+}
+
+const getAlgorithmSummaryPdf = async (req, res, next) => {
+  const fileMethod = 'file: src/controllers/api/algorithm.js - method: getAlgorithmSummaryPdf'
+  try {
+    const resumenValores = await algorithmService.getGeneralSummary()
+
+    const templatePath = path.join(__dirname, '../../utils/pdfs/templates/algorithm-summary.ejs')
+    const html = await ejs.renderFile(templatePath, { resumenValores })
+
+    const options = {
+      format: 'A4',
+      printBackground: true,
+      margin: { top: 10, right: 10, bottom: 10, left: 10 }
+    }
+
+    const pdfBuffer = await html_to_pdf.generatePdf({ content: html }, options)
+
+    const base64 = pdfBuffer.toString('base64')
+
+    return res.json({
+      error: false,
+      pdf: base64
+    })
+  } catch (error) {
+    logger.error(`${fileMethod} | ${error.message}`)
+    next(error)
+  }
+}
+
 module.exports = {
-  getAlgorithmResult
+  getAlgorithmResult,
+  getAlgorithmSummary,
+  getAlgorithmSummaryPdf
 }

--- a/src/routes/api/algorithm.js
+++ b/src/routes/api/algorithm.js
@@ -7,4 +7,26 @@ const algorithmController = require('../../controllers/api/algorithm')
 
 router.post('/result', algorithmController.getAlgorithmResult)
 
+/**
+ * @swagger
+ * /api/algorithm/summary:
+ *   get:
+ *     summary: Obtiene un resumen de los valores usados en el algoritmo
+ *     responses:
+ *       200:
+ *         description: Resumen generado
+ */
+router.get('/summary', algorithmController.getAlgorithmSummary)
+
+/**
+ * @swagger
+ * /api/algorithm/summary/pdf:
+ *   get:
+ *     summary: Genera un reporte PDF con los valores del algoritmo
+ *     responses:
+ *       200:
+ *         description: PDF generado en base64
+ */
+router.get('/summary/pdf', algorithmController.getAlgorithmSummaryPdf)
+
 module.exports = router

--- a/src/utils/pdfs/templates/algorithm-summary.ejs
+++ b/src/utils/pdfs/templates/algorithm-summary.ejs
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; color: #333; }
+    h1 { color:#0a3d8e; text-align:center; }
+    h2 { background:#0a3d8e; color:#fff; padding:4px; font-size:14px; margin-top:20px; }
+    table { width:100%; border-collapse:collapse; margin-bottom:20px; font-size:12px; }
+    th, td { border:1px solid #ccc; padding:6px; }
+    th { background:#f0f0f0; }
+  </style>
+</head>
+<body>
+  <h1>Parámetros del Algoritmo</h1>
+  <% for (const [nombre, filas] of Object.entries(resumenValores)) { %>
+    <h2><%= nombre %></h2>
+    <% if (filas.length === 0) { %>
+      <p>No hay datos</p>
+    <% } else { %>
+    <table>
+      <thead>
+        <tr>
+          <th>Nombre</th>
+          <th>V1</th>
+          <th>V2</th>
+          <% if ('limite_inferior' in filas[0]) { %>
+            <th>Límite inferior</th>
+            <th>Límite superior</th>
+          <% } %>
+          <% if ('rango' in filas[0]) { %>
+            <th>Rango</th>
+          <% } %>
+        </tr>
+      </thead>
+      <tbody>
+        <% filas.forEach(row => { %>
+          <tr>
+            <td><%= row.nombre %></td>
+            <td><%= row.v1 %></td>
+            <td><%= row.v2 %></td>
+            <% if (row.limite_inferior !== undefined) { %>
+              <td><%= row.limite_inferior %></td>
+              <td><%= row.limite_superior %></td>
+            <% } %>
+            <% if (row.rango !== undefined) { %>
+              <td><%= row.rango %></td>
+            <% } %>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+    <% } %>
+  <% } %>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fetch algorithm ranges from DB and expose them in `/api/algorithm/summary`
- add `/api/algorithm/summary/pdf` endpoint to download summary as a PDF
- create EJS template for algorithm summary PDF

## Testing
- `node generate_postman.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dc8fb09e4832d87074a8ac61f2a51