### PR TITLE
Serve algorithm summary PDF

### DIFF
--- a/src/controllers/api/algorithm.js
+++ b/src/controllers/api/algorithm.js
@@ -76,12 +76,9 @@ const getAlgorithmSummaryPdf = async (req, res, next) => {
 
     const pdfBuffer = await html_to_pdf.generatePdf({ content: html }, options)
 
-    const base64 = pdfBuffer.toString('base64')
-
-    return res.json({
-      error: false,
-      pdf: base64
-    })
+    res.setHeader('Content-Type', 'application/pdf')
+    res.setHeader('Content-Disposition', 'attachment; filename=algorithm-summary.pdf')
+    return res.send(pdfBuffer)
   } catch (error) {
     logger.error(`${fileMethod} | ${error.message}`)
     next(error)

--- a/src/routes/api/algorithm.js
+++ b/src/routes/api/algorithm.js
@@ -25,7 +25,7 @@ router.get('/summary', algorithmController.getAlgorithmSummary)
  *     summary: Genera un reporte PDF con los valores del algoritmo
  *     responses:
  *       200:
- *         description: PDF generado en base64
+ *         description: PDF generado
  */
 router.get('/summary/pdf', algorithmController.getAlgorithmSummaryPdf)
 module.exports = router


### PR DESCRIPTION
## Summary
- serve algorithm summary PDF directly instead of base64
- update swagger description

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ddb19c94c832db7cfe582aad7f966