### PR TITLE
Implement algorithm ranges update endpoint

### DIFF
--- a/postman_collection.json
+++ b/postman_collection.json
@@ -65,6 +65,28 @@
               ]
             }
           }
+        },
+        {
+          "name": "PUT /api/algorithm/ranges",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "url": {
+              "raw": "{{dev}}/api/algorithm/ranges",
+              "host": [
+                "{{dev}}"
+              ],
+              "path": [
+                "api",
+                "algorithm",
+                "ranges"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cat_resultado_referencias_proveedores_algoritmo\": [\n    {\n      \"id_cat_resultado_referencias_proveedores\": 6,\n      \"valor_algoritmo\": \"0\",\n      \"valor_algoritmo_v2\": \"-8\"\n    }\n  ]\n}"
+            }
+          }
         }
       ]
     },

--- a/src/controllers/api/algorithm.js
+++ b/src/controllers/api/algorithm.js
@@ -88,8 +88,25 @@ const getAlgorithmSummaryPdf = async (req, res, next) => {
   }
 }
 
+const updateAlgorithmRanges = async (req, res, next) => {
+  const fileMethod = 'file: src/controllers/api/algorithm.js - method: updateAlgorithmRanges'
+  try {
+    const { body } = req
+    await algorithmService.updateAlgorithmRanges(body)
+
+    return res.json({
+      error: false,
+      message: 'Valores actualizados'
+    })
+  } catch (error) {
+    logger.error(`${fileMethod} | ${error.message}`)
+    next(error)
+  }
+}
+
 module.exports = {
   getAlgorithmResult,
   getAlgorithmSummary,
-  getAlgorithmSummaryPdf
+  getAlgorithmSummaryPdf,
+  updateAlgorithmRanges
 }

--- a/src/routes/api/algorithm.js
+++ b/src/routes/api/algorithm.js
@@ -28,4 +28,6 @@ router.get('/summary', algorithmController.getAlgorithmSummary)
  *         description: PDF generado
  */
 router.get('/summary/pdf', algorithmController.getAlgorithmSummaryPdf)
+
+router.put('/ranges', algorithmController.updateAlgorithmRanges)
 module.exports = router

--- a/src/services/algorithm.js
+++ b/src/services/algorithm.js
@@ -111,6 +111,71 @@ class AlgorithmService {
       referenciasProveedoresScore: mapTable('cat_resultado_referencias_proveedores_algoritmo')
     }
   }
+
+  /**
+   * Update the score and range configuration for the algorithm tables.
+   * The body must contain an object whose keys are the table names and the
+   * values are arrays of rows with the fields to update.
+   *
+   * Example body:
+   * {
+   *   cat_pais_algoritmo: [ { id_pais_algoritmo: 1, valor_algoritmo: 10 } ],
+   *   cat_plantilla_laboral_algoritmo: [
+   *     { id_cat_plantilla_laboral: 2, limite_inferior: 0, limite_superior: 10 }
+   *   ]
+   * }
+   */
+  async updateAlgorithmRanges (changes) {
+    if (!changes || typeof changes !== 'object') return
+
+    const tables = [
+      'cat_pais_algoritmo',
+      'cat_sector_riesgo_sectorial_algoritmo',
+      'cat_sector_clientes_finales_algoritmo',
+      'cat_tiempo_actividad_comercial_algoritmo',
+      'cat_plantilla_laboral_algoritmo',
+      'cat_ventas_anuales_algoritmo',
+      'cat_apalancamiento_algoritmo',
+      'cat_flujo_neto_caja_algoritmo',
+      'cat_capital_contable_algoritmo',
+      'cat_incidencias_legales_algoritmo',
+      'cat_resultado_referencias_proveedores_algoritmo',
+      'cat_payback_algoritmo',
+      'cat_rotacion_cuentas_cobrar_algoritmo',
+      'cat_tipo_cifras_algoritmo',
+      'cat_evolucion_ventas_algoritmo',
+      'cat_score_descripcion_algoritmo'
+    ]
+
+    for (const table of tables) {
+      const rows = changes[table]
+      if (!Array.isArray(rows)) continue
+
+      for (const row of rows) {
+        const idField = Object.keys(row).find(key => key.startsWith('id_'))
+        if (!idField) continue
+
+        const setFields = []
+        for (const field of [
+          'nombre',
+          'valor_algoritmo',
+          'valor_algoritmo_v2',
+          'limite_inferior',
+          'limite_superior',
+          'rango_numerico'
+        ]) {
+          if (Object.prototype.hasOwnProperty.call(row, field)) {
+            setFields.push(`${field} = ${mysqlLib.escape(row[field])}`)
+          }
+        }
+
+        if (setFields.length === 0) continue
+
+        const query = `UPDATE ${table} SET ${setFields.join(', ')} WHERE ${idField} = ${mysqlLib.escape(row[idField])};`
+        await mysqlLib.query(query)
+      }
+    }
+  }
 }
 
 module.exports = new AlgorithmService()


### PR DESCRIPTION
## Summary
- update algorithm service with helper to update all algorithm tables
- expose updateAlgorithmRanges controller
- add PUT `/api/algorithm/ranges` route
- include ranges route in Postman collection with example payload

## Testing
- `npx standard` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc459a00832da993124051943542