### PR TITLE
Fix undefined access when last certification not found

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3096,11 +3096,11 @@ WHERE cer.certificacion_id = (
     SELECT
       c.id_certification
     FROM empresa AS e
-    LEFT JOIN certification AS c ON c.id_empresa = e.emp_id 
+    LEFT JOIN certification AS c ON c.id_empresa = e.emp_id
     WHERE e.emp_rfc = '${rfc}' AND c.estatus_certificacion = 'inicial';
     `
     const { result } = await mysqlLib.query(queryString)
-    return result[0].id_certification
+    return result.length > 0 ? result[0].id_certification : null
   }
 
 
@@ -3115,7 +3115,7 @@ WHERE cer.certificacion_id = (
     LIMIT 1;
     `
     const { result } = await mysqlLib.query(queryString)
-    return result[0].id_certification
+    return result.length > 0 ? result[0].id_certification : null
   }
 
   async guardaRelacionCompradorVendedor(data) {


### PR DESCRIPTION
## Summary
- avoid accessing result[0] when there are no rows in `getLastIdCertification` and `getLastIdCertificationByRfc`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e2fb08614832d80ba440121d38fc6