### PR TITLE
Add isEmpty helper for capital check

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -3296,7 +3296,9 @@ const cuentaConCapital = async (idCertification, customUuid) => {
     const capital_previo_anterior = await certificationService.obtieneCapitalPrevioAnterior(idCertification)
     logger.info(`${fileMethod} | ${customUuid} El capital previo anterior obtenido es: ${JSON.stringify(capital_anterior)}`)
 
-    if (capital_anterior[0].capital == '0.00' || capital_anterior[0].capital == undefined || capital_previo_anterior[0].capital == '0.00' || capital_previo_anterior[0].capital == undefined) {
+    const isEmpty = (value) => value === '0.00' || value === '0' || value === undefined || value === null || value === 0
+
+    if (isEmpty(capital_anterior[0].capital) || isEmpty(capital_previo_anterior[0].capital)) {
       logger.info(`${fileMethod} | ${customUuid} SI se cumple la condición: [Con al menos no tener un periodo contable se va a algoritmo v2]`)
       return false
     } else {


### PR DESCRIPTION
## Summary
- implement `isEmpty` helper in `cuentaConCapital`
- use the helper to evaluate previous capital values

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e3451b774832dada8b98943585d9d