### PR TITLE
Fix tipo cifras null check

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -2293,7 +2293,7 @@ const getScoreTipoCifrasFromSummary = async (
     `file: src/controllers/api/certification.js - method: getScoreTipoCifrasFromSummary`
   try {
     const tipoCifraId = await certificationService.getTipoCifra(id_certification)
-    if (!tipoCifraId) {
+    if (tipoCifraId === null || tipoCifraId === undefined) {
       logger.warn(
         `${fileMethod} | ${customUuid} No se ha podido obtener el tipo de cifra`
       )


### PR DESCRIPTION
## Summary
- treat `id_tipo_cifra` value `0` as valid
- only fall back to v2 when the DB result is truly `null` or `undefined`

## Testing
- `npx --no-install standard` *(fails: 403 Forbidden)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e3fd1d710832d9fc4eb625bb1d93a