### PR TITLE
Fix evolucion ventas null check

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -2293,7 +2293,7 @@ const getScoreTipoCifrasFromSummary = async (
     `file: src/controllers/api/certification.js - method: getScoreTipoCifrasFromSummary`
   try {
     const tipoCifraId = await certificationService.getTipoCifra(id_certification)
-    if (!tipoCifraId) {
+    if (tipoCifraId === null || tipoCifraId === undefined) {
       logger.warn(
         `${fileMethod} | ${customUuid} No se ha podido obtener el tipo de cifra`
       )
@@ -2396,7 +2396,10 @@ const getScoreEvolucionVentasFromSummary = async (
       certificationService.getVentasAnualesAnioPrevioAnterior(id_certification)
     ])
 
-    if (!anioAnterior || !previoAnterior) return { error: true }
+    if (anioAnterior === null || anioAnterior === undefined ||
+        previoAnterior === null || previoAnterior === undefined) {
+      return { error: true }
+    }
 
     const anterior = parseFloat(anioAnterior.ventas_anuales)
     const previo = parseFloat(previoAnterior.ventas_anuales)


### PR DESCRIPTION
## Summary
- handle null result for annual sales evolution

## Testing
- `npx --no-install standard` *(fails: 403 Forbidden)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684e3fd1d710832d9fc4eb625bb1d93a