### PR TITLE
Fix email options for algorithm v2

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4842,7 +4842,11 @@ ${JSON.stringify(info_email_error, null, 2)}
                   const nombre = isSelected
                     ? `<strong>${opt.nombre ?? ''}</strong>`
                     : opt.nombre ?? ''
-                  return `<li>${nombre} (${opt.valor_algoritmo ?? ''})</li>`
+                  const valor =
+                    Number(version_algoritmo) === 2
+                      ? opt.valor_algoritmo_v2 ?? opt.valor_algoritmo ?? ''
+                      : opt.valor_algoritmo ?? ''
+                  return `<li>${nombre} (${valor})</li>`
                 })
                 .join('')
             }</ul>`


### PR DESCRIPTION
## Summary
- ensure email lists algorithm options for the correct algorithm version

## Testing
- `npx standard` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684e45f59b80832d914f3885a0504c1c