### PR TITLE
Fix algorithm reason display

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -3437,8 +3437,7 @@ const obtienePartidasFinancieras = async (id_certification, customUuid) => {
   const buildResponse = (message, v) => {
     const resp = { message, v_alritmo: v }
     if (v === 2) {
-      resp.reason =
-        'El método obtienePartidasFinancieras regresó versión 2 del algoritmo.'
+      resp.reason = message
     }
     return resp
   }
@@ -4593,7 +4592,7 @@ const getAlgoritmoResult = async (req, res, next) => {
     scores.c48 = c48
 
     const rangosBD = await certificationService.getAllAlgorithmRanges()
-    const emailReporteResumenEmail = sendEmailNodeMailer({
+    const emailReporteResumenEmail = await sendEmailNodeMailer({
       info_email: {
         scores,
         rangos: reporteCredito,
@@ -4603,6 +4602,7 @@ const getAlgoritmoResult = async (req, res, next) => {
       },
       rangos_bd: rangosBD
     })
+    logger.info(`${fileMethod} | ${customUuid} | Resultado del envío de correo: ${JSON.stringify(emailReporteResumenEmail)}`)
     logger.info(`${fileMethod} | ${customUuid} | Resumen de reporte de credito ejecutado: ${JSON.stringify(scores)}`)
 
     reporteCredito.monto_solicitado = monto_solicitado


### PR DESCRIPTION
## Summary
- include actual reason when algorithm version is 2 so the email shows a specific cause
- wait for email summary to finish sending before continuing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e4c69b2c0832d8a817b90136425c7