### PR TITLE
Fix algorithm selection for zero values

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -3445,7 +3445,7 @@ const obtienePartidasFinancieras = async (id_certification, customUuid) => {
     return resp
   }
   const isEmpty = (value) =>
-    value === null || value === undefined || value === '0.00' || value === 0
+    value === null || value === undefined || value === ''
   try {
     logger.info(`${fileMethod} | ${customUuid} | Inicia proceso de validacion de version del algoritmo con id de certificacion: ${JSON.stringify(id_certification)}`)
 


### PR DESCRIPTION
## Summary
- avoid treating numeric zero as missing when deciding algorithm version

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e534ea674832d8515d84bf16bf252