### PR TITLE
Add missing range mapping for score descriptions

### DIFF
--- a/src/services/algorithm.js
+++ b/src/services/algorithm.js
@@ -112,7 +112,8 @@ class AlgorithmService {
       flujoNetoScore: mapTable('cat_flujo_neto_caja_algoritmo'),
       paybackScore: mapTable('cat_payback_algoritmo'),
       rotacionCtasXCobrarScore: mapTable('cat_rotacion_cuentas_cobrar_algoritmo'),
-      referenciasProveedoresScore: mapTable('cat_resultado_referencias_proveedores_algoritmo')
+      referenciasProveedoresScore: mapTable('cat_resultado_referencias_proveedores_algoritmo'),
+      scoreDescripcion: mapTable('cat_score_descripcion_algoritmo')
     }
   }
 


### PR DESCRIPTION
## Summary
- include `cat_score_descripcion_algoritmo` ranges in `getGeneralSummary`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e5e09bdd0832d964e22b0e8e83981