### PR TITLE
Fix evolution sales score selection

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -2425,9 +2425,31 @@ const getScoreEvolucionVentasFromSummary = async (
       evolucion_ventas: evolucion
     }
 
+    const toNumber = (val) => {
+      if (val === undefined || val === null) return NaN
+      const clean = String(val).replace('%', '').trim().toLowerCase()
+      if (clean === 'inf') return Infinity
+      if (clean === '-inf') return -Infinity
+      return parseFloat(clean)
+    }
+
+    const getLimits = (entry) => {
+      if (entry.limite_inferior !== undefined && entry.limite_inferior !== null) {
+        const inf = toNumber(entry.limite_inferior)
+        const sup = entry.limite_superior == null ? Infinity : toNumber(entry.limite_superior)
+        return [inf, sup]
+      }
+      if (entry.rango) {
+        const [a, b] = entry.rango.replace(/[()\[\]]/g, '').split(',')
+        const start = toNumber(a)
+        const end = toNumber(b)
+        return [Math.min(start, end), Math.max(start, end)]
+      }
+      return [NaN, NaN]
+    }
+
     const evoScore = parametrosAlgoritmo.evolucionVentasScore.find(e => {
-      const inf = parseFloat(e.limite_inferior)
-      const sup = e.limite_superior == null ? Infinity : parseFloat(e.limite_superior)
+      const [inf, sup] = getLimits(e)
       return evolucion >= inf && evolucion <= sup
     })
     if (!evoScore) return { error: true }


### PR DESCRIPTION
## Summary
- parse numeric ranges when picking evolution sales score

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: 403 Forbidden due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_684e6000f7fc832d81e2f4fa635b9bb6