### PR TITLE
Fix getLastIdCertification when no rows returned

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3100,7 +3100,12 @@ WHERE cer.certificacion_id = (
     WHERE e.emp_rfc = '${rfc}' AND c.estatus_certificacion = 'inicial';
     `
     const { result } = await mysqlLib.query(queryString)
-    return result.length > 0 ? result[0].id_certification : null
+
+    if (Array.isArray(result) && result.length > 0 && result[0]) {
+      return result[0].id_certification
+    }
+
+    return null
   }
 
 
@@ -3115,7 +3120,12 @@ WHERE cer.certificacion_id = (
     LIMIT 1;
     `
     const { result } = await mysqlLib.query(queryString)
-    return result.length > 0 ? result[0].id_certification : null
+
+    if (Array.isArray(result) && result.length > 0 && result[0]) {
+      return result[0].id_certification
+    }
+
+    return null
   }
 
   async guardaRelacionCompradorVendedor(data) {


### PR DESCRIPTION
## Summary
- handle the case where the result from `mysqlLib.query` does not contain rows for `getLastIdCertificationByRfc` and `getLastIdCertification`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68505180347c832d91941fa70a93ca03