### PR TITLE
Fix error when fetching last certification id

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3099,13 +3099,16 @@ WHERE cer.certificacion_id = (
     LEFT JOIN certification AS c ON c.id_empresa = e.emp_id
     WHERE e.emp_rfc = '${rfc}' AND c.estatus_certificacion = 'inicial';
     `
-    const { result } = await mysqlLib.query(queryString)
-
-    if (Array.isArray(result) && result.length > 0 && result[0]) {
-      return result[0].id_certification
+    try {
+      const { result } = await mysqlLib.query(queryString)
+      if (Array.isArray(result) && result.length > 0 && result[0]) {
+        return result[0].id_certification
+      }
+      return null
+    } catch (error) {
+      logger.error(`getLastIdCertification | ${error.message}`)
+      return null
     }
-
-    return null
   }
 
 
@@ -3119,13 +3122,18 @@ WHERE cer.certificacion_id = (
     c.id_certification DESC
     LIMIT 1;
     `
-    const { result } = await mysqlLib.query(queryString)
+    try {
+      const { result } = await mysqlLib.query(queryString)
 
-    if (Array.isArray(result) && result.length > 0 && result[0]) {
-      return result[0].id_certification
+      if (Array.isArray(result) && result.length > 0 && result[0]) {
+        return result[0].id_certification
+      }
+
+      return null
+    } catch (error) {
+      logger.error(`getLastIdCertification | ${error.message}`)
+      return null
     }
-
-    return null
   }
 
   async guardaRelacionCompradorVendedor(data) {


### PR DESCRIPTION
## Summary
- handle database query failure when fetching last certification id

## Testing
- `npx standard` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685053c978c4832dbc6f54f4a03ef69d