### PR TITLE
Show LC score table in credit report email

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4915,6 +4915,18 @@ ${JSON.stringify(info_email_error, null, 2)}
         version_algoritmo = '',
         customUuid: uuid = ''
       } = info_email
+      const scoreLcData = await certificationService.getAllScoreLc().catch(() => [])
+      const scoreLcRows = Array.isArray(scoreLcData)
+        ? scoreLcData
+            .map(
+              ({ score, porcentaje_lc }) => `
+          <tr>
+            <td style="padding: 8px; border: 1px solid #ccc;">${score}</td>
+            <td style="padding: 8px; border: 1px solid #ccc;">${porcentaje_lc}%</td>
+          </tr>`
+            )
+            .join('')
+        : ''
       const tableMap = {
         _01_pais: 'cat_pais_algoritmo',
         _02_sector_riesgo: 'cat_sector_riesgo_sectorial_algoritmo',
@@ -5098,6 +5110,18 @@ ${JSON.stringify(info_email_error, null, 2)}
             </thead>
             <tbody>
               ${detallesTabla}
+            </tbody>
+          </table>
+          <h4 style="color: #337ab7;">Score vs % LC</h4>
+          <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
+            <thead>
+              <tr>
+                <th style="padding: 8px; border: 1px solid #ccc;">Score</th>
+                <th style="padding: 8px; border: 1px solid #ccc;">% LC</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${scoreLcRows}
             </tbody>
           </table>
           ${rangos_bd ? '' : ''}

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3889,6 +3889,19 @@ WHERE cer.certificacion_id = (
     return result[0].porcentaje_lc
   }
 
+  async getAllScoreLc() {
+    const queryString = `
+      SELECT
+          score,
+          porcentaje_lc
+      FROM
+          cat_score_lc
+      ORDER BY score ASC;
+      `
+    const { result } = await mysqlLib.query(queryString)
+    return result
+  }
+
   async saveAlgoritm(id_certification, scores, g45, c46, g46, g49, g48, g51, g52, wu, c48, porcentajeLc) {
     const queryString = `
         INSERT INTO algoritmo_resultado (


### PR DESCRIPTION
## Summary
- add service call to fetch all LC scores
- render LC score table in the credit report email

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685073c149a0832db7dc19f0fed1c563