### PR TITLE
Add score classes table to credit report email

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4927,6 +4927,20 @@ ${JSON.stringify(info_email_error, null, 2)}
             )
             .join('')
         : ''
+
+      const scoreClassData = await certificationService.getAllScoreClasses().catch(() => [])
+      const scoreClassRows = Array.isArray(scoreClassData)
+        ? scoreClassData
+            .map(
+              ({ score_min, score_max, class: clase }) => `
+          <tr>
+            <td style="padding: 8px; border: 1px solid #ccc;">${score_min}</td>
+            <td style="padding: 8px; border: 1px solid #ccc;">${score_max}</td>
+            <td style="padding: 8px; border: 1px solid #ccc;">${clase}</td>
+          </tr>`
+            )
+            .join('')
+        : ''
       const tableMap = {
         _01_pais: 'cat_pais_algoritmo',
         _02_sector_riesgo: 'cat_sector_riesgo_sectorial_algoritmo',
@@ -5108,12 +5122,25 @@ ${JSON.stringify(info_email_error, null, 2)}
                 <th style="padding: 8px; border: 1px solid #ccc; white-space: pre-line;">Explicación</th>
               </tr>
             </thead>
-            <tbody>
+          <tbody>
               ${detallesTabla}
-            </tbody>
-          </table>
-          <h4 style="color: #337ab7;">Score vs % LC</h4>
-          <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
+          </tbody>
+        </table>
+        <h4 style="color: #337ab7;">Score vs Clases</h4>
+        <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
+          <thead>
+            <tr>
+              <th style="padding: 8px; border: 1px solid #ccc;">Score min</th>
+              <th style="padding: 8px; border: 1px solid #ccc;">Score max</th>
+              <th style="padding: 8px; border: 1px solid #ccc;">Clase</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${scoreClassRows}
+          </tbody>
+        </table>
+        <h4 style="color: #337ab7;">Score vs % LC</h4>
+        <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
             <thead>
               <tr>
                 <th style="padding: 8px; border: 1px solid #ccc;">Score</th>

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3902,6 +3902,20 @@ WHERE cer.certificacion_id = (
     return result
   }
 
+  async getAllScoreClasses() {
+    const queryString = `
+      SELECT
+          score_min,
+          score_max,
+          class
+      FROM
+          score_classes_a
+      ORDER BY score_min ASC;
+      `
+    const { result } = await mysqlLib.query(queryString)
+    return result
+  }
+
   async saveAlgoritm(id_certification, scores, g45, c46, g46, g49, g48, g51, g52, wu, c48, porcentajeLc) {
     const queryString = `
         INSERT INTO algoritmo_resultado (


### PR DESCRIPTION
## Summary
- fetch score classes from DB via new `getAllScoreClasses` method
- include Score vs Clases table in credit report notification email

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68507c41cd14832db0503180b37c052c