### PR TITLE
Remove hardcoded score class tables

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4927,6 +4927,25 @@ ${JSON.stringify(info_email_error, null, 2)}
             )
             .join('')
         : ''
+
+      const scoreClassData = await certificationService
+        .getAllScoreClasses()
+        .catch(() => ({ table1: [], table2: [] }))
+      const { table1: scoreClassA, table2: scoreClassB } = scoreClassData
+      const buildRows = data =>
+        Array.isArray(data)
+          ? data
+              .map(
+                ({ score_min, score_max, class: clase }) => `
+          <tr>
+            <td style="padding: 8px; border: 1px solid #ccc;">${score_min} - ${score_max}</td>
+            <td style="padding: 8px; border: 1px solid #ccc;">${clase}</td>
+          </tr>`
+              )
+              .join('')
+          : ''
+      const scoreClassRowsA = buildRows(scoreClassA)
+      const scoreClassRowsB = buildRows(scoreClassB)
       const tableMap = {
         _01_pais: 'cat_pais_algoritmo',
         _02_sector_riesgo: 'cat_sector_riesgo_sectorial_algoritmo',
@@ -5108,12 +5127,36 @@ ${JSON.stringify(info_email_error, null, 2)}
                 <th style="padding: 8px; border: 1px solid #ccc; white-space: pre-line;">Explicación</th>
               </tr>
             </thead>
-            <tbody>
+          <tbody>
               ${detallesTabla}
-            </tbody>
-          </table>
-          <h4 style="color: #337ab7;">Score vs % LC</h4>
-          <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
+          </tbody>
+        </table>
+        <h4 style="color: #337ab7;">Score vs Clases (Tabla 1)</h4>
+        <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
+          <thead>
+            <tr>
+              <th style="padding: 8px; border: 1px solid #ccc;">Score</th>
+              <th style="padding: 8px; border: 1px solid #ccc;">Clase</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${scoreClassRowsA}
+          </tbody>
+        </table>
+        <h4 style="color: #337ab7;">Score vs Clases (Tabla 2)</h4>
+        <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
+          <thead>
+            <tr>
+              <th style="padding: 8px; border: 1px solid #ccc;">Score</th>
+              <th style="padding: 8px; border: 1px solid #ccc;">Clase</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${scoreClassRowsB}
+          </tbody>
+        </table>
+        <h4 style="color: #337ab7;">Score vs % LC</h4>
+        <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
             <thead>
               <tr>
                 <th style="padding: 8px; border: 1px solid #ccc;">Score</th>


### PR DESCRIPTION
## Summary
- remove constant score tables from certification service
- query database for `score_classes_a` and `score_classes_b` when building emails
- log when tables are missing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68507c41cd14832db0503180b37c052c