### PR TITLE
Fix duplicates in getEnviadas query

### DIFF
--- a/src/services/solicitudCredito.js
+++ b/src/services/solicitudCredito.js
@@ -193,7 +193,7 @@ class SolicituCreditoService {
   async getEnviadas(id_emp, idCliente = 0) {
 
     const queryString = `
-      SELECT 
+      SELECT
     sol.id_solicitud_credito,
     sol.id_cliente,
     sol.id_proveedor,
@@ -202,9 +202,9 @@ class SolicituCreditoService {
     emp.emp_razon_social,
     emp.emp_logo,
     cert.id_certification,
-    rc.reporte_pdf,
-    rc.monto_solicitado AS linea_credito_solicitada,
-    rc.plazo,
+    COALESCE(rc.reporte_pdf, rcd.reporte_pdf) AS reporte_pdf,
+    COALESCE(rc.monto_solicitado, rcd.monto_solicitado) AS linea_credito_solicitada,
+    COALESCE(rc.plazo, rcd.plazo) AS plazo,
     rc.score,
     rc.monto_sugerido AS linea_credito_sugerida,
     "" AS ciudad,
@@ -213,14 +213,22 @@ class SolicituCreditoService {
     sol.estatus,
     cert.estatus_certificacion,
     COALESCE(sol.created_at, '') AS fecha_solicitud,
-    COALESCE(rc.created_at, '') AS fecha_reporte
+    COALESCE(rc.created_at, rcd.created_at, '') AS fecha_reporte
 FROM solicitud_credito sol
 LEFT JOIN empresa emp ON emp.emp_id = sol.id_cliente
-LEFT JOIN certification cert ON emp.emp_id = cert.id_empresa AND cert.estatus_certificacion <> 'cancelada'
-LEFT JOIN reporte_credito rc ON rc.id_reporte_credito = sol.id_solicitud_credito AND rc.id_reporte_credito IS NOT NULL
+LEFT JOIN certification cert ON cert.id_certification = (
+        SELECT c.id_certification
+        FROM certification c
+        WHERE c.id_empresa = emp.emp_id
+          AND c.estatus_certificacion <> 'cancelada'
+        ORDER BY c.id_certification DESC
+        LIMIT 1
+    )
+LEFT JOIN reporte_credito rc ON rc.id_reporte_credito = sol.id_solicitud_credito
+LEFT JOIN reporte_credito_descriptivo rcd ON rcd.id_reporte_credito = sol.id_solicitud_credito
 WHERE sol.id_proveedor = ${id_emp}
 
-UNION 
+UNION
 
 SELECT 
     NULL AS id_solicitud_credito,
@@ -246,39 +254,10 @@ SELECT
 FROM solicitud_credito_externos sce
 WHERE sce.emp_id = ${id_emp}
 AND NOT EXISTS (
-    SELECT 1 
-    FROM solicitud_credito sol 
+    SELECT 1
+    FROM solicitud_credito sol
     LEFT JOIN empresa emp ON emp.emp_id = sol.id_cliente
     WHERE emp.emp_rfc = sce.tax_id)
-
-UNION
-
-SELECT 
-    sol.id_solicitud_credito,
-    sol.id_cliente,
-    sol.id_proveedor,
-    emp.emp_rfc,
-    emp.emp_website,
-    emp.emp_razon_social,
-    emp.emp_logo,
-    cert.id_certification,
-    rcd.reporte_pdf,
-    rcd.monto_solicitado AS linea_credito_solicitada,
-    rcd.plazo,
-    NULL AS score,
-    NULL AS linea_credito_sugerida,
-    "" AS ciudad,
-    "" AS consumo_mensual,
-    "" AS metodo_pago,
-    sol.estatus,
-    cert.estatus_certificacion,
-    COALESCE(sol.created_at, '') AS fecha_solicitud,
-    COALESCE(rcd.created_at, '') AS fecha_reporte
-FROM solicitud_credito sol
-INNER JOIN empresa emp ON emp.emp_id = sol.id_cliente
-LEFT JOIN certification cert ON emp.emp_id = cert.id_empresa AND cert.estatus_certificacion <> 'cancelada'
-INNER JOIN reporte_credito_descriptivo rcd ON rcd.id_reporte_credito = sol.id_solicitud_credito
-WHERE sol.id_proveedor = ${id_emp}
     `;
 
     const result = await mysqlLib.query(queryString)


### PR DESCRIPTION
## Summary
- avoid duplicate rows in `getEnviadas` by consolidating `reporte_credito` and `reporte_credito_descriptivo`
- limit certifications to the latest non-cancelled record

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68509ffbcf70832d9b302b272f49cbcf