### PR TITLE
Remove references table from report email

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4957,27 +4957,6 @@ ${JSON.stringify(info_email_error, null, 2)}
       const scoreClassRowsA = buildRows(scoreClassA)
       const scoreClassRowsB = buildRows(scoreClassB)
 
-      const referenciasData = await certificationService
-        .getCatResultadoReferenciasProveedores()
-        .catch(() => [])
-      const referenciasRows = Array.isArray(referenciasData)
-        ? referenciasData
-            .map(
-              ({
-                id_cat_resultado_referencias_proveedores: id,
-                nombre,
-                valor_algoritmo,
-                valor_algoritmo_v2
-              }) => `
-          <tr>
-            <td style="padding: 8px; border: 1px solid #ccc;">${id}</td>
-            <td style="padding: 8px; border: 1px solid #ccc;">${nombre}</td>
-            <td style="padding: 8px; border: 1px solid #ccc;">${valor_algoritmo}</td>
-            <td style="padding: 8px; border: 1px solid #ccc;">${valor_algoritmo_v2}</td>
-          </tr>`
-            )
-            .join('')
-        : ''
 
       const scoreDescripcionData =
         (rangos_bd && rangos_bd.cat_score_descripcion_algoritmo) || []
@@ -5222,20 +5201,6 @@ ${JSON.stringify(info_email_error, null, 2)}
           </thead>
           <tbody>
             ${scoreDescripcionRows}
-          </tbody>
-        </table>
-        <h4 style="color: #337ab7;">Referencias comerciales</h4>
-        <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
-          <thead>
-            <tr>
-              <th style="padding: 8px; border: 1px solid #ccc;">ID</th>
-              <th style="padding: 8px; border: 1px solid #ccc;">Nombre</th>
-              <th style="padding: 8px; border: 1px solid #ccc;">Valor V1</th>
-              <th style="padding: 8px; border: 1px solid #ccc;">Valor V2</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${referenciasRows}
           </tbody>
         </table>
         <h4 style="color: #337ab7;">Score vs % LC</h4>


### PR DESCRIPTION
## Summary
- remove vendor references table from the report email

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850ac9e1884832d80b08992967623f4