### PR TITLE
Fix acid test ratio display

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5716,6 +5716,7 @@ const calculoRatiosFinancieros = async (customUuid, id_certification, calculos_e
       error: false,
       r1_capital_trabajo_numero_veces,
       r2_capital_trabajo_valor_nominal,
+      r3_prueba_acida_numero_veces,
       r4_grado_general_endeudamiento_numero_veces,
       r5_apalancamiento_financiero_numero_veces,
       r6_rotacion_inventarios_numero_veces,


### PR DESCRIPTION
## Summary
- include acid test ratio results when returning financial ratios

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850d3282bf4832db19a582298f37418