### PR TITLE
Fix PDF table headers keep with tables

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4975,6 +4975,7 @@ ${JSON.stringify(info_email_error, null, 2)}
         : ''
 
       const scoreTables = `
+        <div class="table-section">
         <h4 style="color: #337ab7;">Score vs Clases (Tabla 1)</h4>
         <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
           <thead>
@@ -4987,6 +4988,8 @@ ${JSON.stringify(info_email_error, null, 2)}
             ${scoreClassRowsA}
           </tbody>
         </table>
+        </div>
+        <div class="table-section">
         <h4 style="color: #337ab7;">Score vs Clases (Tabla 2)</h4>
         <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
           <thead>
@@ -4999,6 +5002,8 @@ ${JSON.stringify(info_email_error, null, 2)}
             ${scoreClassRowsB}
           </tbody>
         </table>
+        </div>
+        <div class="table-section">
         <h4 style="color: #337ab7;">Score descripción algoritmo</h4>
         <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
           <thead>
@@ -5012,6 +5017,8 @@ ${JSON.stringify(info_email_error, null, 2)}
             ${scoreDescripcionRows}
           </tbody>
         </table>
+        </div>
+        <div class="table-section">
         <h4 style="color: #337ab7;">Score vs % LC</h4>
         <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
           <thead>
@@ -5024,6 +5031,7 @@ ${JSON.stringify(info_email_error, null, 2)}
             ${scoreLcRows}
           </tbody>
         </table>
+        </div>
       `
       const tableMap = {
         _01_pais: 'cat_pais_algoritmo',
@@ -5619,6 +5627,7 @@ ${JSON.stringify(info_email_error, null, 2)}
               </tr>
             </tbody>
           </table>
+          <div class="table-section">
           <h4 style="color: #337ab7;">Detalles</h4>
           <table style="border-collapse: collapse; width: 100%;">
             <thead>
@@ -5635,12 +5644,14 @@ ${JSON.stringify(info_email_error, null, 2)}
               ${detallesTabla}
           </tbody>
         </table>
+        </div>
+        <div class="table-section">
         <h4 style="color: #337ab7;">Ratios financieros</h4>
         <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
           <thead>
-            <tr>
-              <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">Ratio</th>
-              <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">Periodo anterior</th>
+              <tr>
+                <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">Ratio</th>
+                <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">Periodo anterior</th>
               <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">Previo anterior</th>
               <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">Fórmula</th>
               <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">Operación</th>
@@ -5650,6 +5661,8 @@ ${JSON.stringify(info_email_error, null, 2)}
             ${ratioRows}
           </tbody>
         </table>
+        </div>
+        <div class="table-section">
         <h4 style="color: #337ab7;">Cálculos Estado de Balance</h4>
         <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
           <thead>
@@ -5665,6 +5678,8 @@ ${JSON.stringify(info_email_error, null, 2)}
             ${balanceRows}
           </tbody>
         </table>
+        </div>
+        <div class="table-section">
         <h4 style="color: #337ab7;">Cálculos Estado de Resultados</h4>
         <table style="border-collapse: collapse; width: 100%; margin-top: 10px;">
           <thead>
@@ -5702,6 +5717,7 @@ ${JSON.stringify(info_email_error, null, 2)}
         thead { display: table-header-group; }
         tr, th, td { page-break-inside: avoid; }
         h3, h4 { page-break-after: avoid; }
+        .table-section { page-break-inside: avoid; }
       </style>
     `
     const file = { content: `<html><head>${styles}</head><body>${htmlContent}</body></html>` }

--- a/src/utils/pdfs/templates/algorithm-summary.ejs
+++ b/src/utils/pdfs/templates/algorithm-summary.ejs
@@ -5,8 +5,9 @@
   <style>
     body { font-family: Arial, sans-serif; padding: 20px; color: #333; }
     h1 { color:#0a3d8e; text-align:center; }
-    h2 { background:#0a3d8e; color:#fff; padding:4px; font-size:14px; margin-top:20px; }
-    table { width:100%; border-collapse:collapse; margin-bottom:20px; font-size:12px; }
+    h2 { background:#0a3d8e; color:#fff; padding:4px; font-size:14px; margin-top:20px; page-break-after: avoid; }
+    table { width:100%; border-collapse:collapse; margin-bottom:20px; font-size:12px; page-break-inside: avoid; }
+    .table-section { page-break-inside: avoid; }
     th, td { border:1px solid #ccc; padding:6px; }
     th { background:#f0f0f0; }
   </style>
@@ -14,6 +15,7 @@
 <body>
   <h1>Parámetros del Algoritmo</h1>
   <% for (const [nombre, filas] of Object.entries(resumenValores)) { %>
+    <div class="table-section">
     <h2><%= nombre %></h2>
     <% if (filas.length === 0) { %>
       <p>No hay datos</p>
@@ -51,6 +53,7 @@
       </tbody>
     </table>
     <% } %>
+    </div>
   <% } %>
 </body>
 </html>

--- a/src/utils/pdfs/templates/quote-details.ejs
+++ b/src/utils/pdfs/templates/quote-details.ejs
@@ -18,6 +18,7 @@
       margin-bottom: 0px;
       font-size: 1rem;
       color: #575756;
+      page-break-after: avoid;
     }
     .head {
       width: 100%;
@@ -113,6 +114,7 @@
       max-width: 95%;
       margin: 0 auto;
     }
+    .table-section { page-break-inside: avoid; }
     /*** Table Styles **/
     table {
       width: 100%;
@@ -258,6 +260,7 @@
       </div>
     </div>
   </div>
+  <div class="table-section">
   <div class="tabla">
     <table border="0" cellspacing="0" cellpadding="0">
       <thead>
@@ -287,6 +290,7 @@
       <% } %>
 
     </table>
+  </div>
   </div>
   <div class="terminos">
     <div class="detalle-terminos">


### PR DESCRIPTION
## Summary
- keep table headers with their tables in generated PDF reports
- avoid page breaks between titles and tables in algorithm summary and quote details templates

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: 403 Forbidden - GET https://registry.npmjs.org/standard)*

------
https://chatgpt.com/codex/tasks/task_e_6851c09fbebc832dbdc51252e2c27652