### PR TITLE
Fix PDF table titles to stay with tables

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5713,11 +5713,11 @@ ${JSON.stringify(info_email_error, null, 2)}
     const styles = `
       <style>
         body { font-family: Arial, sans-serif; font-size: 12px; line-height: 1.4; color: #333; }
-        table { font-size: 12px; page-break-inside: avoid; width: 100%; border-collapse: collapse; }
+        table { font-size: 12px; page-break-inside: avoid; break-inside: avoid; width: 100%; border-collapse: collapse; }
         thead { display: table-header-group; }
-        tr, th, td { page-break-inside: avoid; }
-        h3, h4 { page-break-after: avoid; }
-        .table-section { page-break-inside: avoid; }
+        tr, th, td { page-break-inside: avoid; break-inside: avoid; }
+        h3, h4 { page-break-after: avoid; break-after: avoid; }
+        .table-section { page-break-inside: avoid; break-inside: avoid; }
       </style>
     `
     const file = { content: `<html><head>${styles}</head><body>${htmlContent}</body></html>` }

--- a/src/utils/pdfs/templates/algorithm-summary.ejs
+++ b/src/utils/pdfs/templates/algorithm-summary.ejs
@@ -6,8 +6,8 @@
     body { font-family: Arial, sans-serif; padding: 20px; color: #333; }
     h1 { color:#0a3d8e; text-align:center; }
     h2 { background:#0a3d8e; color:#fff; padding:4px; font-size:14px; margin-top:20px; page-break-after: avoid; }
-    table { width:100%; border-collapse:collapse; margin-bottom:20px; font-size:12px; page-break-inside: avoid; }
-    .table-section { page-break-inside: avoid; }
+    table { width:100%; border-collapse:collapse; margin-bottom:20px; font-size:12px; page-break-inside: avoid; break-inside: avoid; }
+    .table-section { page-break-inside: avoid; break-inside: avoid; }
     th, td { border:1px solid #ccc; padding:6px; }
     th { background:#f0f0f0; }
   </style>

--- a/src/utils/pdfs/templates/quote-details.ejs
+++ b/src/utils/pdfs/templates/quote-details.ejs
@@ -114,7 +114,7 @@
       max-width: 95%;
       margin: 0 auto;
     }
-    .table-section { page-break-inside: avoid; }
+    .table-section { page-break-inside: avoid; break-inside: avoid; }
     /*** Table Styles **/
     table {
       width: 100%;


### PR DESCRIPTION
## Summary
- ensure style prevents page breaks between table headers and content

## Testing
- `npx --no-install standard` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851c58ed3c0832db4a3e1ce4eaf0492