### PR TITLE
Filtra referencias vencidas en getCertificacionReferenciasComerciales

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -2251,17 +2251,21 @@ WHERE cer.certificacion_id = (
 
   async getCertificacionReferenciasComerciales(id_certification) {
     const queryString = `
-      
-    SELECT 
-    crc.*, 
+
+    SELECT
+    crc.*,
     cecc.*
-      FROM 
+      FROM
     certification_referencia_comercial crc
-      INNER JOIN 
+      INNER JOIN
     certification_empresa_cliente_contacto cecc
     ON crc.id_certification_referencia_comercial = cecc.id_referencia_comercial
-      WHERE 
+      LEFT JOIN
+    certification_referencia_comercial_external_invitation crcei
+    ON crcei.id_referencia = crc.id_certification_referencia_comercial
+      WHERE
     crc.id_certification = ${id_certification} AND contestada = 'si'
+      AND (crcei.estatus_referencia IS NULL OR crcei.estatus_referencia <> 'vencida')
       `;
     const result = await mysqlLib.query(queryString);
     return result;


### PR DESCRIPTION
## Summary
- add left join with `certification_referencia_comercial_external_invitation` in `getCertificacionReferenciasComerciales`
- filter out expired references (`estatus_referencia = 'vencida'`)

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851f44fe034832da1dcc9e1c1ccb822