### PR TITLE
Add status to commercial references

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -2174,12 +2174,14 @@ WHERE cer.certificacion_id = (
       crc.rfc,
       crc.contestada,
       d.codigo_postal,
-      crc.id_pais
+      crc.id_pais,
+      crcei.estatus_referencia
     FROM certification_referencia_comercial AS crc
     LEFT JOIN domicilio AS d ON d.domicilio_id = crc.id_direccion
     LEFT JOIN certification AS c ON c.id_certification = crc.id_certification
+    LEFT JOIN certification_referencia_comercial_external_invitation AS crcei ON crcei.id_referencia = crc.id_certification_referencia_comercial
     WHERE crc.id_certification = ${id_certification}
-    GROUP BY crc.razon_social, crc.denominacion, crc.rfc, d.codigo_postal, crc.id_pais
+    GROUP BY crc.razon_social, crc.denominacion, crc.rfc, d.codigo_postal, crc.id_pais, crcei.estatus_referencia
     ORDER BY id_certification_referencia_comercial DESC;
     `
     const { result } = await mysqlLib.query(queryString)


### PR DESCRIPTION
## Summary
- include `estatus_referencia` from `certification_referencia_comercial_external_invitation`
  when fetching commercial references

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852092eea70832d8bab5ccd6fc50adb