### PR TITLE
Fix references retrieval

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -1259,12 +1259,12 @@ const getReferenciaComercialForm = async (req, res, next) => {
     const get_referencias_comerciales = await certificationService.getReferenciasComercialesByIdCertification(id_certification)
     if (!get_referencias_comerciales) return next(boom.badRequest(`El ID de certificacion ${id_certification} no tiene referecias insertadas`))
 
-    // El query puede devolver referencias duplicadas. Filtrarlas por los datos
-    // relevantes para evitar repetir las mismas referencias con diferente id
+    // El query puede devolver registros repetidos por los joins. Filtrar por
+    // id de referencia para evitar duplicados exactos
     const referenciasUnicas = []
     const seenReferencias = new Set()
     for (const ref of get_referencias_comerciales) {
-      const key = `${ref.razon_social}-${ref.denominacion}-${ref.rfc}`
+      const key = ref.id_certification_referencia_comercial
       if (!seenReferencias.has(key)) {
         seenReferencias.add(key)
         referenciasUnicas.push(ref)

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -2145,7 +2145,7 @@ WHERE cer.certificacion_id = (
   async getReferenciasComercialesByIdCertificationScore(id_certification) {
     const queryString = `
      SELECT
-      MIN(crc.id_certification_referencia_comercial) AS id_certification_referencia_comercial,
+      crc.id_certification_referencia_comercial,
       crc.razon_social,
       crc.denominacion,
       crc.rfc,
@@ -2153,13 +2153,12 @@ WHERE cer.certificacion_id = (
     FROM certification_referencia_comercial AS crc
     LEFT JOIN domicilio AS d ON d.domicilio_id = crc.id_direccion
     LEFT JOIN certification AS c ON c.id_certification = crc.id_certification
-     LEFT JOIN certification_referencia_comercial_external_invitation AS crcei ON crcei.id_referencia = crc.id_certification_referencia_comercial
+    LEFT JOIN certification_referencia_comercial_external_invitation AS crcei ON crcei.id_referencia = crc.id_certification_referencia_comercial
     WHERE crc.id_certification = ${id_certification}
       AND crc.contestada = 'si'
       AND crc.referencia_valida = 'true'
       AND (crcei.estatus_referencia IS NULL OR crcei.estatus_referencia <> 'vencida')
-    GROUP BY crc.razon_social, crc.denominacion, crc.rfc, d.codigo_postal
-    ORDER BY id_certification_referencia_comercial DESC;
+    ORDER BY crc.id_certification_referencia_comercial DESC;
     `
     const { result } = await mysqlLib.query(queryString)
     return result
@@ -2168,7 +2167,7 @@ WHERE cer.certificacion_id = (
   async getReferenciasComercialesByIdCertification(id_certification) {
     const queryString = `
        SELECT
-        MIN(crc.id_certification_referencia_comercial) AS id_certification_referencia_comercial,
+        crc.id_certification_referencia_comercial,
         crc.razon_social,
         crc.denominacion,
         crc.rfc,
@@ -2183,8 +2182,7 @@ WHERE cer.certificacion_id = (
       LEFT JOIN certification AS c ON c.id_certification = crc.id_certification
       LEFT JOIN certification_referencia_comercial_external_invitation AS crcei ON crcei.id_referencia = crc.id_certification_referencia_comercial
       WHERE crc.id_certification = ${id_certification}
-      GROUP BY crc.razon_social, crc.denominacion, crc.rfc, d.codigo_postal, crc.id_pais, crcei.estatus_referencia, crc.referencia_valida, crc.observaciones
-      ORDER BY id_certification_referencia_comercial DESC;
+      ORDER BY crc.id_certification_referencia_comercial DESC;
       `
     const { result } = await mysqlLib.query(queryString)
     return result


### PR DESCRIPTION
## Summary
- avoid deduping by business info in `getReferenciaComercialForm`
- return every commercial reference record from the DB

## Testing
- `npm test` *(fails: Missing script)*
- `npx --no-install standard` *(fails due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_6852363ebf38832da08ccab7a9703c03