### PR TITLE
Add algorithm version validation table to email

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5048,6 +5048,65 @@ ${JSON.stringify(info_email_error, null, 2)}
         version_algoritmo = '',
         customUuid: uuid = ''
       } = info_email
+
+      const capitalOk = id_certification
+        ? await cuentaConCapital(id_certification, uuid)
+        : false
+      const cajaBancosOk = id_certification
+        ? await cuentaCajaBancos(id_certification, uuid)
+        : false
+      const clientesOk = id_certification
+        ? await cuentaClienteCuentasXCobrar(id_certification, uuid)
+        : false
+      const inventariosOk = id_certification
+        ? await cuentaInventarios(id_certification, uuid)
+        : false
+
+      const validacionesVersionRows = [
+        {
+          label: 'Capital contable en ambos periodos',
+          value: capitalOk
+        },
+        {
+          label: 'Caja y bancos e inventarios en ambos periodos',
+          value: cajaBancosOk
+        },
+        {
+          label: 'Clientes y cuentas por cobrar e inventarios en ambos periodos',
+          value: clientesOk
+        },
+        {
+          label: 'Inventarios en ambos periodos',
+          value: inventariosOk
+        }
+      ]
+        .map(
+          ({ label, value }, idx) => `
+          <tr style="background-color:${idx % 2 === 0 ? '#ffffff' : '#f5f5f5'};">
+            <td style="padding: 6px 8px; border: 1px solid #ddd;">${label}</td>
+            <td style="padding: 6px 8px; border: 1px solid #ddd;">${
+              value ? 'Cumple' : 'No cumple'
+            }</td>
+          </tr>`
+        )
+        .join('')
+
+      const validacionesVersionTable = `
+        <div class="table-section">
+        <table style="border-collapse: collapse; width: 100%;">
+          <caption>Validaciones para selección de versión de algoritmo</caption>
+          <thead>
+            <tr>
+              <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">Validación</th>
+              <th style="padding: 6px 8px; border: 1px solid #e0e0e0;">¿Se cumple?</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${validacionesVersionRows}
+          </tbody>
+        </table>
+        </div>
+      `
       const scoreLcData = await certificationService.getAllScoreLc().catch(() => [])
       const scoreLcRows = Array.isArray(scoreLcData)
         ? scoreLcData
@@ -5982,6 +6041,7 @@ ${JSON.stringify(info_email_error, null, 2)}
               </tr>
             </tbody>
           </table>
+          ${validacionesVersionTable}
           <div class="table-section">
           <table style="border-collapse: collapse; width: 100%;">
             <caption>Detalles</caption>


### PR DESCRIPTION
## Summary
- show validations to choose algorithm version in notification email

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_6852e8dc7a04832d841c7c377696585b