### PR TITLE
Reorder references tables in PDF

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6435,6 +6435,7 @@ ${JSON.stringify(info_email_error, null, 2)}
         </table>
         ${financialTables}
         ${scoreTables}
+        ${referenceTables}
         <div class="table-section">
         <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 10px;">
           <caption>Referencias comerciales consideradas</caption>
@@ -6470,7 +6471,6 @@ ${JSON.stringify(info_email_error, null, 2)}
           </tbody>
         </table>
         </div>
-        ${referenceTables}
           ${rangos_bd ? '' : ''}
         </div>
       `


### PR DESCRIPTION
## Summary
- tweak PDF generation order so commercial reference tables follow the '16. Referencias comerciales' section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68536557b9e8832d9e4965ac1f880ed2