### PR TITLE
Implement controlante logic for related companies

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -536,6 +536,26 @@ const iniciaCertificacion = async (req, res, next) => {
       return next(boom.badRequest(`La empresa con ID ${id_empresa} no tiene relacion con el usuario ${id_usuario}`))
     }
 
+    if (empresas_relacionadas && empresas_relacionadas.length > 0) {
+      if (empresas_relacionadas.length === 1) {
+        empresas_relacionadas[0].controlante = 1
+      } else {
+        let controlantes = 0
+        for (const empresa of empresas_relacionadas) {
+          if (parseInt(empresa.controlante) === 1) {
+            controlantes += 1
+            empresa.controlante = 1
+          } else {
+            empresa.controlante = 0
+          }
+        }
+        if (controlantes !== 1) {
+          logger.warn(`${fileMethod} | Se debe indicar exactamente una empresa controlante`)
+          return next(boom.badRequest('Debe existir una sola empresa controlante'))
+        }
+      }
+    }
+
     const insertCert = await certificationService.iniciaCertification(body)
     if (!insertCert.result) {
       logger.warn(`${fileMethod} | No se insertaron los datos primarios para la certificación`);

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -1476,17 +1476,19 @@ WHERE cer.certificacion_id = (
   }
 
   async insertEmpresasRel(id, body) {
-    const { razon_social, pais } = body
+    const { razon_social, pais, controlante } = body
     const queryString = `
-    INSERT INTO certification_empresas_relacionadas 
+    INSERT INTO certification_empresas_relacionadas
       (id_certification,
       razon_social,
-      pais
-      ) 
-    VALUES 
+      pais,
+      controlante
+      )
+    VALUES
       (${id},
       '${razon_social}',
-      '${pais}');
+      '${pais}',
+      ${controlante})
   `
     const result = await mysqlLib.query(queryString)
     return result


### PR DESCRIPTION
## Summary
- enforce single controlling company in `iniciaCertificacion`
- store `controlante` value when inserting related companies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685435ab8a80832d807e899aa47dcbd0