### PR TITLE
Update swagger with controlante field

### DIFF
--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -163,6 +163,12 @@ router.post('/certificar-reset', authMiddleware, certificationController.resetCe
  *                 items:
  *                   type: object
  *                   properties:
+ *                     razon_social:
+ *                       type: string
+ *                       example: "Empresa Controladora S.A. de C.V."
+ *                     pais:
+ *                       type: string
+ *                       example: "México"
  *                     controlante:
  *                       type: integer
  *                       description: |


### PR DESCRIPTION
## Summary
- document `controlante` field for `POST /api/certification/iniciaCertificacion`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685443d7bdcc832d8bc65ba650e2b740