### PR TITLE
Fix Swagger for iniciaCertificacion

### DIFF
--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -163,6 +163,12 @@ router.post('/certificar-reset', authMiddleware, certificationController.resetCe
  *                 items:
  *                   type: object
  *                   properties:
+ *                     razon_social:
+ *                       type: string
+ *                       example: "Empresa Relacionada S.A. de C.V."
+ *                     pais:
+ *                       type: string
+ *                       example: "México"
  *                     controlante:
  *                       type: integer
  *                       description: |


### PR DESCRIPTION
## Summary
- add `razon_social`, `pais` and `controlante` fields for `empresas_relacionadas` in Swagger docs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854475f602c832da51314113698f2ae