### PR TITLE
Fix country example in certification swagger

### DIFF
--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -167,8 +167,8 @@ router.post('/certificar-reset', authMiddleware, certificationController.resetCe
  *                       type: string
  *                       example: "Empresa Relacionada S.A. de C.V."
  *                     pais:
- *                       type: string
- *                       example: "México"
+ *                       type: integer
+ *                       example: 11
  *                     controlante:
  *                       type: integer
  *                       description: |


### PR DESCRIPTION
## Summary
- update `empresas_relacionadas` Swagger example to use numeric `pais` value

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68544bc38bcc832dafb27421a0eea1f2