### PR TITLE
Implement conteo_error_rfc for accionistas

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -539,12 +539,14 @@ const iniciaCertificacion = async (req, res, next) => {
     if (accionistas && accionistas.length > 0) {
       if (accionistas.length === 1) {
         accionistas[0].controlante = 1
+        if (accionistas[0].conteo_error_rfc === undefined) accionistas[0].conteo_error_rfc = 0
       } else {
         let controlantes = 0
         for (const accionista of accionistas) {
           if (parseInt(accionista.controlante) === 1) {
             controlantes += 1
             accionista.controlante = 1
+            if (accionista.conteo_error_rfc === undefined) accionista.conteo_error_rfc = 0
           } else {
             accionista.controlante = 0
           }

--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -128,6 +128,10 @@ router.post('/certificar-reset', authMiddleware, certificationController.resetCe
  *                         • 1 = es la controlante
  *                         • 0 = no lo es
  *                       example: 1
+ *                     conteo_error_rfc:
+ *                       type: integer
+ *                       description: Conteo de intentos fallidos de validación de RFC del accionista controlante
+ *                       example: 0
  *               empresas:
  *                 type: array
  *                 items:

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -1690,9 +1690,9 @@ WHERE cer.certificacion_id = (
   async insertaAccionista(insertIdCert, accionista) {
     const queryString = `
       INSERT INTO certification_accionistas
-        (id_certification, razon_social, denominacion, rfc, controlante)
+        (id_certification, razon_social, denominacion, rfc, controlante, conteo_error_rfc)
       VALUES
-        (${insertIdCert}, '${accionista.razon_social}', ${accionista.denominacion}, '${accionista.rfc}', ${accionista.controlante})
+        (${insertIdCert}, '${accionista.razon_social}', ${accionista.denominacion}, '${accionista.rfc}', ${accionista.controlante}, ${accionista.conteo_error_rfc ?? null})
     `;
     const result = await mysqlLib.query(queryString);
     return result;


### PR DESCRIPTION
## Summary
- handle `conteo_error_rfc` in the accionista controller logic
- store the value when inserting accionistas in the service
- document the new field in the swagger for `iniciaCertificacion`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68546a5602c4832d8aa7cfc8f56fc626