### PR TITLE
Expose Konesh response

### DIFF
--- a/src/controllers/api/konesh.js
+++ b/src/controllers/api/konesh.js
@@ -502,7 +502,8 @@ exports.genericKoneshRequest = async (req, res, next) => {
       return res.json({
         success: false,
         mensaje: 'El RFC tiene problemas en el SAT',
-        detalle: problematicEntry[0]
+        detalle: problematicEntry[0],
+        data_konesh: konesh_api_des
       })
     }
 
@@ -510,11 +511,12 @@ exports.genericKoneshRequest = async (req, res, next) => {
     if (razonSat !== razon_social) {
       return res.json({
         success: false,
-        mensaje: 'La razón social proporcionada no coincide con la registrada en el SAT'
+        mensaje: 'La razón social proporcionada no coincide con la registrada en el SAT',
+        data_konesh: konesh_api_des
       })
     }
 
-    return res.json({ success: true, mensaje: 'RFC y razón social validados correctamente' })
+    return res.json({ success: true, mensaje: 'RFC y razón social validados correctamente', data_konesh: konesh_api_des })
   } catch (error) {
     next(error)
   }

--- a/src/routes/api/konesh.js
+++ b/src/routes/api/konesh.js
@@ -146,6 +146,20 @@ router.post('/ValidaListaService', decryptMiddleware,  konesh.validaListaService
  *     responses:
  *       200:
  *         description: Resultado de la validación del RFC y la razón social
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 mensaje:
+ *                   type: string
+ *                 detalle:
+ *                   type: string
+ *                 data_konesh:
+ *                   type: object
+ *                   description: Objeto completo retornado por la API de Konesh (ya desencriptado)
  */
 router.get('/validar-rfc', konesh.genericKoneshRequest)
 


### PR DESCRIPTION
## Summary
- expose decrypted Konesh response on `/api/konesh/validar-rfc`
- document new `data_konesh` field in Swagger

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6854754a0c88832d906a65fa93ae1855