### PR TITLE
Add BLOC controlante endpoint

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4129,6 +4129,52 @@ const validacionBloc = async (req, res, next) => {
   }
 }
 
+const consultaBlocEmpresaControlante = async (req, res, next) => {
+  const fileMethod = `file: src/controllers/api/certification.js - method: consultaBlocEmpresaControlante`
+  try {
+    const { nombre, apellido } = req.body
+
+    const params = await utilitiesService.getParametros()
+
+    const getUrl = (param) => {
+      const conf = params.find(item => item.nombre === param)
+      return conf ? conf.valor : null
+    }
+
+    const sat69bUrl = getUrl('block_lista_sat_69B_presuntos_inexistentes')
+      ?.replace('||', encodeURIComponent(nombre))
+      .replace('||', encodeURIComponent(apellido))
+
+    const ofacUrl = getUrl('bloc_ofac')
+      ?.replace('||', encodeURIComponent(nombre))
+      .replace('||', encodeURIComponent(apellido))
+
+    const concursosUrl = getUrl('bloc_consursos_mercantiles')
+      ?.replace('||', encodeURIComponent(nombre))
+
+    const proveedoresUrl = getUrl('bloc_provedores_contratistas')
+      ?.replace('||', encodeURIComponent(nombre))
+      .replace('||', encodeURIComponent(apellido))
+
+    const [sat69bResp, ofacResp, concursosResp, proveedoresResp] = await Promise.all([
+      sat69bUrl ? axios.get(sat69bUrl) : { data: null },
+      ofacUrl ? axios.get(ofacUrl) : { data: null },
+      concursosUrl ? axios.get(concursosUrl) : { data: null },
+      proveedoresUrl ? axios.get(proveedoresUrl) : { data: null }
+    ])
+
+    return res.json({
+      bloc_sat69b: sat69bResp.data,
+      bloc_ofac: ofacResp.data,
+      bloc_concursos_mercantiles: concursosResp.data,
+      bloc_proveedores_contratistas: proveedoresResp.data
+    })
+  } catch (error) {
+    logger.error(`${fileMethod} | Error durante la ejecución: ${JSON.stringify(error)}`)
+    next(error)
+  }
+}
+
 const generaReporteInformativoCredito = async (req, res, next) => {
   const fileMethod = `file: src/controllers/api/certification.js - method: generaReporteInformativoCredito`;
   const consulta_bloc = req.consultaBloc;
@@ -16759,6 +16805,7 @@ module.exports = {
   getInfoContactoReferido,
   getDataReporteGlobal,
   validacionBloc,
+  consultaBlocEmpresaControlante,
   consultaBloc,
   getMontoPlazo
   /* validarCertificacionBloc */

--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -1107,6 +1107,46 @@ router.post('/validacionBloc', /*decryptMiddleware, authMiddleware,*/ certificat
 
 /**
  * @swagger
+ * /api/certification/consultaBlocEmpresaControlante:
+ *   post:
+ *     tags:
+ *       - Certificación
+ *     summary: Consulta BLOC para empresa controlante
+ *     description: Obtiene información de SAT 69-B, OFAC, concursos mercantiles y proveedores/contratistas boletinados por gobierno.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               nombre:
+ *                 type: string
+ *                 example: "EMPRESA"
+ *               apellido:
+ *                 type: string
+ *                 example: "SA DE CV"
+ *     responses:
+ *       200:
+ *         description: Respuesta con la información de los servicios BLOC
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 bloc_sat69b:
+ *                   type: object
+ *                 bloc_ofac:
+ *                   type: object
+ *                 bloc_concursos_mercantiles:
+ *                   type: object
+ *                 bloc_proveedores_contratistas:
+ *                   type: object
+ */
+router.post('/consultaBlocEmpresaControlante', /*decryptMiddleware, authMiddleware,*/ certificationController.consultaBlocEmpresaControlante)
+
+/**
+ * @swagger
  * /api/certification/consultaBloc/{idEmpresa}:
  *   get:
  *     tags:


### PR DESCRIPTION
## Summary
- add `consultaBlocEmpresaControlante` controller
- expose new route `/api/certification/consultaBlocEmpresaControlante`
- document new endpoint in swagger

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68548745f7f0832d897567372efe711e