### PR TITLE
Fix consultaBlocEmpresaControlante optional apellido

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4132,7 +4132,7 @@ const validacionBloc = async (req, res, next) => {
 const consultaBlocEmpresaControlante = async (req, res, next) => {
   const fileMethod = `file: src/controllers/api/certification.js - method: consultaBlocEmpresaControlante`
   try {
-    const { nombre, apellido } = req.query
+    const { nombre, apellido = '' } = req.query
 
     const params = await utilitiesService.getParametros()
 

--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -1122,7 +1122,7 @@ router.post('/validacionBloc', /*decryptMiddleware, authMiddleware,*/ certificat
  *         description: Nombre de la empresa controlante
  *       - in: query
  *         name: apellido
- *         required: true
+ *         required: false
  *         schema:
  *           type: string
  *         description: Apellido o denominación complementaria


### PR DESCRIPTION
## Summary
- allow `apellido` query parameter to be optional in consulta BLOC endpoint
- update swagger docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685493692bb0832d9153a2ba1a1126fe