### PR TITLE
Call obtenerDemandas in iniciaCertificacion

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -556,6 +556,15 @@ const iniciaCertificacion = async (req, res, next) => {
           return next(boom.badRequest('Debe existir un solo accionista controlante'))
         }
       }
+
+      const accionistaControlante = accionistas.find(
+        a => parseInt(a.controlante) === 1
+      )
+      if (accionistaControlante && accionistaControlante.razon_social) {
+        const nombreEmpresaControlante = accionistaControlante.razon_social
+        const demandas = await obtenerDemandas(nombreEmpresaControlante)
+        debug(`${fileMethod} | Demandas obtenidas: ${JSON.stringify(demandas)}`)
+      }
     }
 
     const insertCert = await certificationService.iniciaCertification(body)


### PR DESCRIPTION
## Summary
- call `obtenerDemandas` inside `iniciaCertificacion` using the controlling shareholder name

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854a46a7b1c832d8fa1c567c08977ec