### PR TITLE
Add demanda resumen analysis on certification init

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -562,8 +562,29 @@ const iniciaCertificacion = async (req, res, next) => {
       )
       if (accionistaControlante && accionistaControlante.razon_social) {
         const nombreEmpresaControlante = accionistaControlante.razon_social
-        const demandas = await obtenerDemandas(nombreEmpresaControlante)
-        debug(`${fileMethod} | Demandas obtenidas: ${JSON.stringify(demandas)}`)
+        const respuestaDemandas = await obtenerDemandas(nombreEmpresaControlante)
+        debug(`${fileMethod} | Demandas obtenidas: ${JSON.stringify(respuestaDemandas)}`)
+
+        const hayDemandaPenal = respuestaDemandas.data?.demandas?.some(d =>
+          d.tipo_proceso?.toLowerCase() === 'penal'
+        )
+
+        const haceUnAño = new Date()
+        haceUnAño.setFullYear(haceUnAño.getFullYear() - 1)
+
+        const demandasMercantilesRecientes = respuestaDemandas.data?.demandas?.filter(d =>
+          d.tipo_proceso?.toLowerCase() === 'mercantil' &&
+          new Date(d.fecha) >= haceUnAño
+        )
+
+        const hayDosOMasIncidenciasRecientes = demandasMercantilesRecientes?.length >= 2
+
+        const resumenDemandas = {
+          hay_demanda_penal: hayDemandaPenal,
+          hay_2_o_mas_mercantiles_recientes: hayDosOMasIncidenciasRecientes
+        }
+
+        debug(`${fileMethod} | Resumen demandas: ${JSON.stringify(resumenDemandas)}`)
       }
     }
 


### PR DESCRIPTION
## Summary
- analyze demand info in `iniciaCertificacion`
- keep resumenDemandas object in memory for later business rules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854a92151c0832d9d9c8afb2458e21b