### PR TITLE
Integrate controlante score call

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4676,6 +4676,12 @@ const getAlgoritmoResult = async (req, res, next) => {
 
     logger.info(`${fileMethod} | ${customUuid} Reporte de credito 06: ${JSON.stringify(reporteCredito)}`)
 
+    const influencia_controlante = await getControlanteScoreFromSummary(
+      id_certification,
+      parametrosAlgoritmo,
+      customUuid
+    )
+
     const ventas_anuales = await getScoreVentasAnualesFromSummary(
       id_certification,
       algoritmo_v,


### PR DESCRIPTION
## Summary
- call `getControlanteScoreFromSummary` within `getAlgoritmoResult`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854d2cf08a0832db36387bfe661b532