### PR TITLE
Fix influencia controlante table in PDF

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6641,7 +6641,7 @@ ${JSON.stringify(info_email_error, null, 2)}
 
       const referenceTables = variablesReference
         .map(([, label, table]) => {
-          const rows = (rangos_bd && Array.isArray(rangos_bd[table]) ? rangos_bd[table] : [])
+          const rowItems = (rangos_bd && Array.isArray(rangos_bd[table]) ? rangos_bd[table] : [])
             .map((opt, idx) => {
               const v1 = opt.valor_algoritmo ?? '-'
               const v2 = opt.valor_algoritmo_v2 ?? opt.valor_algoritmo ?? '-'
@@ -6653,6 +6653,7 @@ ${JSON.stringify(info_email_error, null, 2)}
                 </tr>`
             })
             .join('')
+          const rows = rowItems || `<tr><td colspan="3" style="padding: 6px 8px; border: 1px solid #ddd; text-align: center;">No hay información disponible</td></tr>`
           return `
             <div class="table-section">
             <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 10px;">

--- a/src/services/algorithm.js
+++ b/src/services/algorithm.js
@@ -103,7 +103,7 @@ class AlgorithmService {
       plantillaLaboralScore: mapTable('cat_plantilla_laboral_algoritmo'),
       sectorClienteFinalScore: mapTable('cat_sector_clientes_finales_algoritmo'),
       tiempoActividadScore: mapTable('cat_tiempo_actividad_comercial_algoritmo'),
-      influenciaControlanteScore: [],
+      influenciaControlanteScore: mapTable('cat_influencia_controlante_algoritmo'),
       ventasAnualesScore: mapTable('cat_ventas_anuales_algoritmo'),
       tipoCifrasScore: mapTable('cat_tipo_cifras_algoritmo'),
       incidenciasLegalesScore: mapTable('cat_incidencias_legales_algoritmo'),
@@ -149,6 +149,7 @@ class AlgorithmService {
       'cat_rotacion_cuentas_cobrar_algoritmo',
       'cat_tipo_cifras_algoritmo',
       'cat_evolucion_ventas_algoritmo',
+      'cat_influencia_controlante_algoritmo',
       'cat_score_descripcion_algoritmo'
     ]
 

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -1773,6 +1773,7 @@ WHERE cer.certificacion_id = (
       'cat_flujo_neto_caja_algoritmo',
       'cat_capital_contable_algoritmo',
       'cat_incidencias_legales_algoritmo',
+      'cat_influencia_controlante_algoritmo',
       'cat_resultado_referencias_proveedores_algoritmo',
       'cat_payback_algoritmo',
       'cat_rotacion_cuentas_cobrar_algoritmo',


### PR DESCRIPTION
## Summary
- include `cat_influencia_controlante_algoritmo` when loading algorithm ranges
- add influence table mapping in algorithm service
- support updating influence table from algorithm service
- show "No hay información disponible" when algorithm tables are empty

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854e3e192f8832db02133497bb272b5