### PR TITLE
Add logging for nodemailer errors

### DIFF
--- a/src/controllers/api/auth.js
+++ b/src/controllers/api/auth.js
@@ -760,7 +760,7 @@ const enviaEncuestaEmail = async (info_email) => {
     const info = await transporter.sendMail(mailOptions)
     return info
   } catch (error) {
-    logger.info(`Error en el envio de correo electronico: ${JSON.stringify(error)} - ${fileMethod}`)
+    logger.error(`Error en el envio de correo electronico: ${JSON.stringify(error)} - ${fileMethod}`)
   }
 }
 

--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6849,7 +6849,7 @@ ${JSON.stringify(info_email_error, null, 2)}
     const info = await transporter.sendMail(mailOptions)
     return info
   } catch (error) {
-    logger.info(`Error en el envio de correo electronico: ${error} - ${fileMethod}`)
+    logger.error(`Error en el envio de correo electronico: ${error} - ${fileMethod}`)
   }
 }
 

--- a/src/controllers/api/cron.js
+++ b/src/controllers/api/cron.js
@@ -241,7 +241,7 @@ const enviarEmailRegistrosSemanal = async (registros, total_registros) => {
         console.log({info})
         return info
     } catch (error) {
-        console.log(error)
+        logger.error(`Error al enviar correo de registros semanales: ${JSON.stringify(error)}`)
     }
 }
 
@@ -350,7 +350,7 @@ const enviarEmailSaldoEmpresas = async (saldo_empresas) => {
         console.log({info})
         return info
     } catch (error) {
-        console.log(error)
+        logger.error(`Error al enviar correo de saldo de empresas: ${JSON.stringify(error)}`)
     }
 }
 


### PR DESCRIPTION
## Summary
- improve error logging for nodemailer email failures

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854f32d3060832d88560c3c02b7e095