### PR TITLE
Fix duplicate table in PDF generation

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5413,9 +5413,7 @@ ${JSON.stringify(info_email_error, null, 2)}
         customUuid: uuid = ''
       } = info_email
 
-      const selectedRule = String(rangos._07_influencia_controlante_regla || '').toLowerCase()
-
-
+      
       const moneyFormatterAlg = new Intl.NumberFormat('es-MX', {
         style: 'currency',
         currency: 'MXN'
@@ -5902,37 +5900,6 @@ ${JSON.stringify(info_email_error, null, 2)}
         </table>
         </div>`
 
-      const controlanteRows = (rangos_bd && Array.isArray(rangos_bd.cat_influencia_controlante)
-        ? rangos_bd.cat_influencia_controlante
-        : [])
-        .map((opt, idx) => {
-          const desc = opt.descripcion ?? opt.nombre ?? '-'
-          const val = opt.valor_algoritmo ?? '-'
-          const isSel = selectedRule && desc.toLowerCase() === selectedRule
-          const descHtml = isSel ? `<strong>${desc}</strong>` : desc
-          return `
-          <tr style="background-color:${idx % 2 === 0 ? '#ffffff' : '#f5f5f5'};">
-            <td style="padding: 6px 8px; border: 1px solid #ddd;">${descHtml}</td>
-            <td style="padding: 6px 8px; border: 1px solid #ddd;">${val}</td>
-          </tr>`
-        })
-        .join('')
-
-      const controlanteCatalogTable = `
-        <div class="table-section">
-        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 10px;">
-          <caption>Catálogo Influencia Controlante</caption>
-          <thead style="background-color: #f2f2f2;">
-            <tr>
-              <th>Descripción</th>
-              <th>Valor Algoritmo</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${controlanteRows || '<tr><td colspan="2" style="padding: 6px 8px; border: 1px solid #ddd; text-align: center;">Sin registros disponibles</td></tr>'}
-          </tbody>
-        </table>
-        </div>`
 
       const refDescartadasTable = `
         <div class="table-section">
@@ -6092,7 +6059,7 @@ ${JSON.stringify(info_email_error, null, 2)}
             tableHtml += `${refConsideradasTable}${refDescartadasTable}`
           }
           if (key === '_07_influencia_controlante') {
-            tableHtml += empresaControlanteTable + controlanteCatalogTable
+            tableHtml += empresaControlanteTable
           }
           return tableHtml
         })


### PR DESCRIPTION
## Summary
- remove duplicate "Catálogo Influencia Controlante" table from PDF generation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855852e74e4832db70f92e7d866060a