### PR TITLE
Fix BLOC consultation network failure

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4273,12 +4273,18 @@ const consultaBlocEmpresaControlanteData = async (nombre, apellido = '') => {
     ?.replace('||', encodeURIComponent(nombre))
     .replace('||', encodeURIComponent(apellido))
 
-  const [sat69bResp, ofacResp, concursosResp, proveedoresResp] = await Promise.all([
-    sat69bUrl ? axios.get(sat69bUrl) : { data: null },
-    ofacUrl ? axios.get(ofacUrl) : { data: null },
-    concursosUrl ? axios.get(concursosUrl) : { data: null },
-    proveedoresUrl ? axios.get(proveedoresUrl) : { data: null }
-  ])
+  const requests = [
+    sat69bUrl ? axios.get(sat69bUrl) : Promise.resolve({ data: null }),
+    ofacUrl ? axios.get(ofacUrl) : Promise.resolve({ data: null }),
+    concursosUrl ? axios.get(concursosUrl) : Promise.resolve({ data: null }),
+    proveedoresUrl ? axios.get(proveedoresUrl) : Promise.resolve({ data: null })
+  ]
+
+  const results = await Promise.allSettled(requests)
+
+  const [sat69bResp, ofacResp, concursosResp, proveedoresResp] = results.map(r =>
+    r.status === 'fulfilled' ? r.value : { data: null }
+  )
 
   return {
     bloc_sat69b: sat69bResp.data,


### PR DESCRIPTION
## Summary
- handle network errors gracefully in the BLOC consultation helper

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685587c3a9cc832dbbf966a564d0c49d