### PR TITLE
Add razon_sat_rfc field to iniciaCertificacion

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -555,6 +555,7 @@ const iniciaCertificacion = async (req, res, next) => {
           accionista.controlante = 0
         }
         if (accionista.conteo_error_rfc === undefined) accionista.conteo_error_rfc = 0
+        if (accionista.razon_sat_rfc === undefined) accionista.razon_sat_rfc = ''
       }
       if (controlantes > 1) {
         logger.warn(`${fileMethod} | Se debe indicar como máximo un accionista controlante`)
@@ -7946,6 +7947,7 @@ const updateCertificacion = async (req, res, next) => {
           } else {
             accionista.controlante = 0
           }
+          if (accionista.razon_sat_rfc === undefined) accionista.razon_sat_rfc = ''
         }
         if (controlantes !== 1) {
           logger.warn(`${fileMethod} - Se debe indicar exactamente un accionista controlante`)

--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -132,6 +132,10 @@ router.post('/certificar-reset', authMiddleware, certificationController.resetCe
  *                       type: integer
  *                       description: Conteo de intentos fallidos de validación de RFC del accionista controlante
  *                       example: 0
+ *                     razon_sat_rfc:
+ *                       type: string
+ *                       description: Razón social reportada por el SAT para el RFC proporcionado
+ *                       example: "RAZON SOCIAL DEL SAT"
  *               empresas:
  *                 type: array
  *                 items:

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -1690,9 +1690,9 @@ WHERE cer.certificacion_id = (
   async insertaAccionista(insertIdCert, accionista) {
     const queryString = `
       INSERT INTO certification_accionistas
-        (id_certification, razon_social, denominacion, rfc, controlante, conteo_error_rfc)
+        (id_certification, razon_social, denominacion, rfc, controlante, conteo_error_rfc, razon_sat_rfc)
       VALUES
-        (${insertIdCert}, '${accionista.razon_social}', ${accionista.denominacion}, '${accionista.rfc}', ${accionista.controlante}, ${accionista.conteo_error_rfc ?? null})
+        (${insertIdCert}, '${accionista.razon_social}', ${accionista.denominacion}, '${accionista.rfc}', ${accionista.controlante}, ${accionista.conteo_error_rfc ?? null}, ${mysqlLib.escape(accionista.razon_sat_rfc)})
     `;
     const result = await mysqlLib.query(queryString);
     return result;
@@ -4186,6 +4186,7 @@ WHERE cer.certificacion_id = (
         razon_social = ${mysqlLib.escape(body.razonSocial)},
         controlante = ${mysqlLib.escape(body.controlante)},
         rfc = ${mysqlLib.escape(body.rfc)},
+        razon_sat_rfc = ${mysqlLib.escape(body.razon_sat_rfc)},
         updated_at = CURRENT_TIMESTAMP
       WHERE id_certification = ${mysqlLib.escape(body.idCertification)};
     `;


### PR DESCRIPTION
## Summary
- allow `iniciaCertificacion` to accept `razon_sat_rfc` within accionistas
- save the new value to `certification_accionistas`
- document new property in swagger

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855b15f0d70832daf2519c829d1f6f2