### PR TITLE
Add Etiqueta column to ratios table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6753,7 +6753,7 @@ ${JSON.stringify(info_email_error, null, 2)}
           <caption>Ratios financieros</caption>
           <thead style="background-color: #f2f2f2;">
               <tr>
-                <th style="background-color: #000; color: #fff;">R</th>
+                <th style="background-color: #000; color: #fff;">Etiqueta</th>
                 <th style="background-color: #000; color: #fff;">Ratio</th>
                 <th>Periodo anterior</th>
               <th>Previo anterior</th>


### PR DESCRIPTION
## Summary
- rename the header for the ratios table to `Etiqueta`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856f7f765dc832d966531486178e333