### PR TITLE
Fix certification initialization bug

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -582,7 +582,9 @@ const iniciaCertificacion = async (req, res, next) => {
     const uniqueIncidencias = []
     const seenKeys = new Set()
     
-    await certificationService.deleteDemandas(certificacion.result[0].id_certification)
+    if (certificacion.result.length > 0) {
+      await certificationService.deleteDemandas(certificacion.result[0].id_certification)
+    }
     if (incidencias_legales && incidencias_legales.length > 0) {
       for (let i = 0; i < incidencias_legales.length; i++) {
         const item = incidencias_legales[i];


### PR DESCRIPTION
## Summary
- fix iniciaCertificacion when company has no existing certification

## Testing
- `npm test --silent`
- `npx standard --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6856fc62eb78832daf0ddeb7760b1aa9