### PR TITLE
Fix error when referencias_comerciales is not an array

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -1182,6 +1182,17 @@ const guardaReferenciasComerciales = async (req, res, next) => {
   try {
     const { body } = req;
     const { id_certification, id_empresa, referencias_comerciales } = body
+    if (!Array.isArray(referencias_comerciales)) {
+      logger.warn(
+        `${fileMethod} | referencias_comerciales no es un arreglo valido: ${JSON.stringify(
+          referencias_comerciales
+        )}`
+      )
+      return next(
+        boom.badRequest('El formato de referencias comerciales no es válido')
+      )
+    }
+
     let contactos = []
 
     const [empresa_origen] = await companiesService.getEmpresaById(id_empresa)


### PR DESCRIPTION
## Summary
- add type validation for `referencias_comerciales` in the certification controller

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run format` *(fails: Missing script)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6857180d3550832d96f3f7ba4aae444c