### PR TITLE
Remove extra controlante tables from PDF

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5979,7 +5979,11 @@ ${JSON.stringify(info_email_error, null, 2)}
         'alerta_preventiva_reserva',
         'calculos_estado_balance',
         'calculos_estado_resultados',
-        'ratio_financiero'
+        'ratio_financiero',
+        '_07_influencia_controlante_sat_69b',
+        '_07_influencia_controlante_ofac',
+        '_07_influencia_controlante_mercantiles_proveedores',
+        '_07_influencia_controlante_contratistas_boletinados'
       ]
       const detallesTables = Object.entries(rangos)
         .filter(([key, val]) =>


### PR DESCRIPTION
## Summary
- exclude extra controlante score tables from PDF generation

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: E403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_685757a55b1c832d9940b778449a6338