### PR TITLE
Compute capital_contable in financial save

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -1176,6 +1176,12 @@ const guardaPartidasFinancieras = async (req, res, next) => {
         resultado_ejercicios_anteriores +
         resultado_ejercicios +
         otro_capital
+
+      anterior.capital_contable =
+        capital_social +
+        resultado_ejercicios_anteriores +
+        resultado_ejercicios +
+        otro_capital
     }
 
     if (body.partida_estado_balance_periodo_contable_previo_anterior) {
@@ -1225,6 +1231,12 @@ const guardaPartidasFinancieras = async (req, res, next) => {
         total_pasivo_largo_plazo + otros_pasivos_largo_plazo
 
       previo.total_capital_contable_pat =
+        capital_social +
+        resultado_ejercicios_anteriores +
+        resultado_ejercicios +
+        otro_capital
+
+      previo.capital_contable =
         capital_social +
         resultado_ejercicios_anteriores +
         resultado_ejercicios +
@@ -8137,6 +8149,12 @@ const updatePartidasFinancieras = async (req, res, next) => {
         resultado_ejercicios_anteriores +
         resultado_ejercicios +
         otro_capital
+
+      anterior.capital_contable =
+        capital_social +
+        resultado_ejercicios_anteriores +
+        resultado_ejercicios +
+        otro_capital
     }
 
     if (body.partida_estado_balance_periodo_contable_previo_anterior) {
@@ -8148,6 +8166,12 @@ const updatePartidasFinancieras = async (req, res, next) => {
         otro_capital = 0
       } = previo
       previo.total_capital_contable_pat =
+        capital_social +
+        resultado_ejercicios_anteriores +
+        resultado_ejercicios +
+        otro_capital
+
+      previo.capital_contable =
         capital_social +
         resultado_ejercicios_anteriores +
         resultado_ejercicios +


### PR DESCRIPTION
## Summary
- calculate capital_contable as the sum of capital components when saving or updating financial entries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68579f755ac4832db22f17174a953406