### PR TITLE
Highlight total row in PDF scores table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6164,7 +6164,10 @@ ${JSON.stringify(info_email_error, null, 2)}
         <table border="1" cellspacing="0" cellpadding="4" style="border-collapse: collapse; width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 8px;">
           <tbody>
             ${sumatoriaScoreRows}
-            <tr><td>Total</td><td>${sumatoriaScores}</td></tr>
+            <tr style="background:#e3f2fd;">
+              <td>Total</td>
+              <td style="color:#0a3d8e; font-weight:bold;">${sumatoriaScores}</td>
+            </tr>
           </tbody>
         </table>
         </div>`


### PR DESCRIPTION
## Summary
- highlight the total row in the Sumatoria de scores PDF table

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68598baecdcc832d9771be0f275d95c6