### PR TITLE
Add buyer and seller info table to quote PDF

### DIFF
--- a/src/utils/pdfs/templates/quote-details.ejs
+++ b/src/utils/pdfs/templates/quote-details.ejs
@@ -260,6 +260,29 @@
       </div>
     </div>
   </div>
+  <div class="tabla">
+    <table border="0" cellspacing="0" cellpadding="0">
+      <thead>
+        <tr>
+          <th>Rol</th>
+          <th>Razón social</th>
+          <th>RFC</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Vendedor</td>
+          <td><%= data.empresa_vendedora_razon_social %></td>
+          <td><%= data.empresa_vendedora_rfc %></td>
+        </tr>
+        <tr>
+          <td>Comprador</td>
+          <td><%= data.empresa_compradora_razon_social %></td>
+          <td><%= data.empresa_compradora_rfc %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
   <div class="table-section">
   <div class="tabla">
     <table border="0" cellspacing="0" cellpadding="0">


### PR DESCRIPTION
## Summary
- include buyer and seller business name and RFC in quote PDF

## Testing
- `npm test` *(fails: Missing script test)*

------
https://chatgpt.com/codex/tasks/task_e_68598be197b0832d94767457abea409f