### PR TITLE
Fix sum calculation for TipoCifras score

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5237,10 +5237,7 @@ const getAlgoritmoResult = async (req, res, next) => {
       tiempoActividadScore: tiempo_actividad.valor_algoritmo,
       influenciaControlanteScore: influencia_controlante.score, //'Pendiente de consumo de api con información de investigacion ante el SAT'// Influencia de empresa controlante
       ventasAnualesScore: Number(algoritmo_v?.v_alritmo) === 2 ? '0' : ventas_anuales.score,
-      tipoCifrasScore:
-        Number(algoritmo_v?.v_alritmo) === 2
-          ? '0'
-          : reporteCredito._09_tipo_cifras?.score,
+      tipoCifrasScore: reporteCredito._09_tipo_cifras?.score,
       incidenciasLegalesScore: incidencias_legales.score,
       evolucionVentasScore: Number(algoritmo_v?.v_alritmo) === 2 ? '0' : evolucion_ventas.score,
       apalancamientoScore: Number(algoritmo_v?.v_alritmo) === 2 ? '0' : apalancamiento.score,


### PR DESCRIPTION
## Summary
- ensure `tipoCifrasScore` is counted in the G45 calculation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6859aa124f20832d88687f5f168e4ba0