### PR TITLE
Update sendEmailNodeMailer PDF tables

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6036,7 +6036,7 @@ ${JSON.stringify(info_email_error, null, 2)}
 
       const refConsideradasTable = `
         <div class="table-section">
-        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0 auto; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
+        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
           <caption style="caption-side: top; margin-bottom: 6px;">Referencias comerciales consideradas</caption>
           <thead style="background-color: #f2f2f2;">
             <tr>
@@ -6056,7 +6056,7 @@ ${JSON.stringify(info_email_error, null, 2)}
 
       const refDescartadasTable = `
         <div class="table-section">
-        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0 auto; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
+        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
           <caption style="caption-side: top; margin-bottom: 6px;">Referencias comerciales descartadas</caption>
           <thead style="background-color: #f2f2f2;">
             <tr>
@@ -6086,7 +6086,7 @@ ${JSON.stringify(info_email_error, null, 2)}
       const empresaControlanteTable = `
         <div class="table-section" style="margin-bottom: 10px;">
         <h3 style="font-size: 12px; margin-bottom: 6px;">7. Influencia de Empresa Controlante</h3>
-        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0 auto; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
+        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
           <tbody>
             <tr><td>Empresa Controlante</td><td>${formatField(rangos._07_influencia_controlante_empresa)}</td></tr>
             <tr><td>RFC</td><td>${formatField(rangos._07_influencia_controlante_rfc)}</td></tr>
@@ -6155,7 +6155,7 @@ ${JSON.stringify(info_email_error, null, 2)}
       const sumatoriaScoresTable = `
         <div class="table-section" style="margin-bottom: 10px;">
         <h3 style="font-size: 12px; margin-bottom: 6px; text-align: center;">Sumatoria de scores</h3>
-        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0 auto; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
+        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
           <tbody>
             ${sumatoriaScoreRows}
             <tr style="background:#0a3d8e; color:#fff; font-weight:bold;">
@@ -6166,21 +6166,9 @@ ${JSON.stringify(info_email_error, null, 2)}
         </table>
         </div>`
 
-
-      const excludedKeys = [
-        'alertas',
-        'alerta_preventiva_reserva',
-        'calculos_estado_balance',
-        'calculos_estado_resultados',
-        'ratio_financiero',
-        '_07_influencia_controlante_sat_69b',
-        '_07_influencia_controlante_ofac',
-        '_07_influencia_controlante_mercantiles_proveedores',
-        '_07_influencia_controlante_contratistas_boletinados'
-      ]
       const detallesTables = Object.entries(rangos)
         .filter(([key, val]) =>
-          !excludedKeys.includes(key) && val && typeof val === 'object'
+          SCORE_KEYS.includes(key) && val && typeof val === 'object'
         )
         .map(([key, val]) => {
           const descripcion = val.descripcion ?? val.caso ?? val.tipo ?? '-'
@@ -6275,7 +6263,7 @@ ${JSON.stringify(info_email_error, null, 2)}
           let tableHtml = `
             <div class="table-section" style="margin-bottom: 10px;">
             <h3 style="font-size: 12px; margin-bottom: 6px;">${titulo}</h3>
-            <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0 auto; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
+            <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
               <tbody>
                 ${rows.join('')}
               </tbody>
@@ -6867,7 +6855,7 @@ ${JSON.stringify(info_email_error, null, 2)}
 
       const financialTables = `
         <div class="table-section">
-        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0 auto; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
+        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
           <caption>Partidas Financieras - Estado de Balance</caption>
           <thead style="background-color: #f2f2f2;">
             <tr>
@@ -6885,7 +6873,7 @@ ${JSON.stringify(info_email_error, null, 2)}
         </table>
         </div>
         <div class="table-section">
-        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0 auto; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
+        <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; margin: 0; width: auto; max-width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
           <caption>Partidas Financieras - Estado de Resultados</caption>
           <thead style="background-color: #f2f2f2;">
             <tr>


### PR DESCRIPTION
## Summary
- restrict extra detail tables to SCORE_KEYS only
- left-align generated tables in nodemailer PDF

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859b6154ce4832d9f8863343db115dc