### PR TITLE
Add reusable Konesh request method

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const axios = require('axios')
+const { callKoneshApi } = require('./konesh')
 const debug = require('debug')('old-api:certification-router')
 const fsp = require('fs').promises
 const html_to_pdf = require('html-pdf-node')
@@ -8948,8 +8949,7 @@ const validacionesReferenciasComercialesValidas = async (data, empresa_referenci
         }
       }
 
-      const headers = { headers: { "Content-Type": "application/json" } }
-      const konesh_api = await axios.post(konesh_url_valid_rfc, request, headers)
+      const konesh_api = await callKoneshApi(rfc_contacto, globalConfig)
       if (konesh_api.status === 200) {
         razon_social_konesh = await descifra_konesh(konesh_api.data.transactionResponse01[0].data04)
         logger.info(`${fileMethod} | Razon social obtenida de KONESH: ${JSON.stringify(razon_social_konesh)}`)

--- a/src/controllers/api/companies.js
+++ b/src/controllers/api/companies.js
@@ -20,6 +20,7 @@ const uploadVideoS3 = require('../../utils/uploadVideoS3')
 const sns = require('../../utils/sns')
 const utilitiesService = require('../../services/utilities')
 const axios = require('axios')
+const { callKoneshApi } = require('./konesh')
 const createTokenJWT = require('../../utils/createTokenJWT')
 const validateEmailRegex = require('../../utils/validateEmailRegex')
 const koneshService = require('../../services/konesh')
@@ -211,8 +212,7 @@ exports.createCompany = async (req, res, next) => {
     }
     logger.info(`Se forma el request para consumir konesh - ${JSON.stringify(request)} - ${fileMethod}`)
 
-    const headers = { headers: { "Content-Type": "application/json" } }
-    const konesh_api = await axios.post(konesh_url_valid_rfc, request, headers)
+    const konesh_api = await callKoneshApi(rfc, globalConfig)
     if (konesh_api.status === 200) {
       logger.info(`Respuesta Konesh: ${JSON.stringify(konesh_api.data)} - ${fileMethod}`)
       konesh_api_des.transactionResponse01 = [

--- a/src/controllers/api/konesh.js
+++ b/src/controllers/api/konesh.js
@@ -445,6 +445,27 @@ exports.cifra = async (req, res, next) => {
   }
 }
 
+exports.callKoneshApi = async (rfc, globalConfig) => {
+  const konesh_url_valid_rfc = globalConfig.find(item => item.nombre === 'konesh_url_valid_rfc').valor
+  const textCifrado = await cifra_konesh(rfc)
+
+  const request = {
+    credentials: {
+      usuario: globalConfig.find(item => item.nombre === 'konesh_usuario').valor,
+      token: globalConfig.find(item => item.nombre === 'konesh_token').valor,
+      password: globalConfig.find(item => item.nombre === 'konesh_password').valor,
+      cuenta: globalConfig.find(item => item.nombre === 'konesh_cuenta').valor
+    },
+    issuer: {
+      rfc: globalConfig.find(item => item.nombre === 'konesh_issuer').valor
+    },
+    list: { list: [textCifrado] }
+  }
+
+  const headers = { headers: { 'Content-Type': 'application/json' } }
+  return axios.post(konesh_url_valid_rfc, request, headers)
+}
+
 exports.genericKoneshRequest = async (req, res, next) => {
   try {
     const { rfc, razon_social } = req.query


### PR DESCRIPTION
## Summary
- centralize the call to Konesh API in `konesh.js`
- use the new `callKoneshApi` helper in `companies.js` and `certification.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859caaeda8c832da6db93fecaf2f8d8