### PR TITLE
Adjust request property names in financial PDF

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6730,13 +6730,8 @@ ${JSON.stringify(info_email_error, null, 2)}
               reqPath = 'compartir_estado_balance'
             } else if (field === 'compartir_resultado') {
               reqPath = 'compartir_estado_resultados'
-            } else if (
-              field === 'compartir_estado_balance' ||
-              field === 'compartir_estado_resultados'
-            ) {
-              reqPath = field
             } else {
-              reqPath = `${prefix}_anterior.${field}`
+              reqPath = field
             }
             return `
           <tr style="background-color:${idx % 2 === 0 ? '#ffffff' : '#f5f5f5'};">


### PR DESCRIPTION
## Summary
- remove nested prefix when showing request property names in financial tables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859cd787ec4832dbe1ba123499504cd