### PR TITLE
Set TZ for Node

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// Fijar zona horaria para todas las operaciones con fecha
+process.env.TZ = 'America/Mexico_City'
+
 const { server: { port } } = require('./config')
 const logger = require('../src/utils/logs/logger')
 const { startCronJobs } = require('./controllers/api/cron')


### PR DESCRIPTION
## Summary
- force Node process timezone to America/Mexico_City

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859d2294fc0832d9dab50ff405c6c91