### PR TITLE
Update algorithm validation order

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5765,38 +5765,38 @@ ${JSON.stringify(info_email_error, null, 2)}
             </tr>
             <tr>
               <td>2</td>
+              <td style="background-color: #000; color: #fff;">No presenta Ventas (PARTIDA 27) en al menos un cierre contable<br><small>ventas_anuales</small></td>
+              <td><strong>Valor:</strong> ${ventasAnterior}</td>
+              <td><strong>Valor:</strong> ${ventasPrevio}</td>
+              <td>${msg(resVentas)}</td>
+            </tr>
+            <tr>
+              <td>3</td>
               <td style="background-color: #000; color: #fff;">Si en al menos uno de los dos periodos contables no se tiene registrado un valor para capital contable, se ejecuta el algoritmo sin EEFF.<br><small>capital_contable</small></td>
               <td><strong>Valor:</strong> ${capitalAnterior}</td>
               <td><strong>Valor:</strong> ${capitalPrevio}</td>
               <td>${msg(resCapital)}</td>
             </tr>
             <tr>
-              <td>3</td>
+              <td>4</td>
               <td style="background-color: #000; color: #fff;">Si en cualquier periodo contable faltan tanto el valor de caja y bancos como el de inventarios, se ejecuta el algoritmo sin EEFF.<br><small>caja_bancos, saldo_inventarios</small></td>
               <td><strong>Caja y bancos:</strong> ${cajaAnterior}<br><strong>Inventarios:</strong> ${invAnterior}</td>
               <td><strong>Caja y bancos:</strong> ${cajaPrevio}<br><strong>Inventarios:</strong> ${invPrevio}</td>
               <td>${msgCajaInv(resCajaInv)}</td>
             </tr>
             <tr>
-              <td>4</td>
+              <td>5</td>
               <td style="background-color: #000; color: #fff;">Si en cualquier periodo contable faltan tanto el valor de clientes y cuentas por cobrar como el de inventarios, se ejecuta el algoritmo sin EEFF.<br><small>saldo_cliente_cuenta_x_cobrar, saldo_inventarios</small></td>
               <td><strong>Clientes y ctas x cobrar:</strong> ${cxcAnterior}<br><strong>Inventarios:</strong> ${invAnterior}</td>
               <td><strong>Clientes y ctas x cobrar:</strong> ${cxcPrevio}<br><strong>Inventarios:</strong> ${invPrevio}</td>
               <td>${msg(resClientesInv)}</td>
             </tr>
             <tr>
-              <td>5</td>
+              <td>6</td>
               <td style="background-color: #000; color: #fff;">Proveedores sin datos en ambos periodos<br><small>proveedores</small></td>
               <td><strong>Valor:</strong> ${provAnterior}</td>
               <td><strong>Valor:</strong> ${provPrevio}</td>
               <td>${msg(resProveedores)}</td>
-            </tr>
-            <tr>
-              <td>6</td>
-              <td style="background-color: #000; color: #fff;">Ventas no reportadas en al menos un periodo<br><small>ventas_anuales</small></td>
-              <td><strong>Valor:</strong> ${ventasAnterior}</td>
-              <td><strong>Valor:</strong> ${ventasPrevio}</td>
-              <td>${msg(resVentas)}</td>
             </tr>
             <tr>
               <td>7</td>


### PR DESCRIPTION
## Summary
- reorder algorithm validation table in certification email
- include missing sales validation as the second rule

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ad6bc9874832d936dfd2618761373