### PR TITLE
Add environment indicator to email subjects

### DIFF
--- a/src/controllers/api/auth.js
+++ b/src/controllers/api/auth.js
@@ -750,10 +750,11 @@ const enviaEncuestaEmail = async (info_email) => {
     <p>Número de clientes a crédito: ${info_email.numero_clientes_a_credito}</p>
     <p>Rango de ventas a crédito mensual: ${info_email.rango_ventas_credito_mensual}</p>
     `
+    const envLabel = process.env.NODE_ENV === 'production' ? 'Productivo' : 'Desarrollo'
     const mailOptions = {
       from: `"credibusiness" <${email_sender_encuesta}>`,
       to: lista_contactos_encuesta.map(d => d.Email).join(','),
-      subject: 'Encuesta Empresa',
+      subject: `[${envLabel}] Encuesta Empresa`,
       html: htmlContent
     }
 

--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -7109,6 +7109,8 @@ ${JSON.stringify(info_email_error, null, 2)}
       return
     }
 
+    const envLabel = process.env.NODE_ENV === 'production' ? 'Productivo' : 'Desarrollo'
+    subject = `[${envLabel}] ${subject}`
     const mailOptions = {
       from: `"credibusiness" <${email_sender_error_reporte_credito}>`,
       to: lista_contactos_error_reporte_credito.map(d => d.Email).join(','),

--- a/src/controllers/api/cron.js
+++ b/src/controllers/api/cron.js
@@ -241,10 +241,11 @@ const enviarEmailRegistrosSemanal = async (registros, total_registros) => {
 </html>
         `
 
+        const envLabel = process.env.NODE_ENV === 'production' ? 'Productivo' : 'Desarrollo'
         const mailOptions = {
           from: `"credibusiness" <${email_sender_encuesta}>`,
           to: correos_reporte_semanal,
-          subject: 'Resumen semanal de nuevos registros',
+          subject: `[${envLabel}] Resumen semanal de nuevos registros`,
           html: htmlContent
         }
 
@@ -349,11 +350,12 @@ const enviarEmailSaldoEmpresas = async (saldo_empresas) => {
 </body>
 </html>
         `
-// 
+//
+        const envLabel = process.env.NODE_ENV === 'production' ? 'Productivo' : 'Desarrollo'
         const mailOptions = {
           from: `"credibusiness" <${email_sender_encuesta}>`,
           to: correos_reporte_semanal,
-          subject: 'Resumen semanal de consumo de folios',
+          subject: `[${envLabel}] Resumen semanal de consumo de folios`,
           html: htmlContent
         }
 


### PR DESCRIPTION
## Summary
- prefix Nodemailer email subjects with environment label

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685adb47a010832d8fc89994767a4e26