### PR TITLE
Add environment label in NodeMailer emails

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -7109,6 +7109,8 @@ ${JSON.stringify(info_email_error, null, 2)}
       return
     }
 
+    const envLabel = process.env.NODE_ENV === 'production' ? 'Productivo' : 'Desarrollo'
+    subject = `[${envLabel}] ${subject}`
     const mailOptions = {
       from: `"credibusiness" <${email_sender_error_reporte_credito}>`,
       to: lista_contactos_error_reporte_credito.map(d => d.Email).join(','),

--- a/src/controllers/api/cron.js
+++ b/src/controllers/api/cron.js
@@ -349,7 +349,6 @@ const enviarEmailSaldoEmpresas = async (saldo_empresas) => {
 </body>
 </html>
         `
-// 
         const mailOptions = {
           from: `"credibusiness" <${email_sender_encuesta}>`,
           to: correos_reporte_semanal,


### PR DESCRIPTION
## Summary
- add environment prefix for sendEmailNodeMailer
- revert environment prefix for other mail functions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685adb47a010832d8fc89994767a4e26