### PR TITLE
Update algorithm validation table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5750,6 +5750,7 @@ ${JSON.stringify(info_email_error, null, 2)}
             <tr>
               <th>No.</th>
               <th style="background-color: #000; color: #fff;">Variable condicionante</th>
+              <th>No.</th>
               <th>Variables condicionales</th>
               <th>Periodo anterior (${yearAnterior})</th>
               <th>Periodo previo anterior (${yearPrevio})</th>
@@ -5760,6 +5761,7 @@ ${JSON.stringify(info_email_error, null, 2)}
             <tr>
               <td>1</td>
               <td style="background-color: #000; color: #fff;">La cuenta de PROVEEDORES (PARTIDA 13) (+) la cuenta Acreedores y préstamos bancarios (PARTIDA 14) NO SON REPORTADAS CONJUNTAMENTE EN LOS 2 PERIODOS CONTABLES EVALUADOS (ES DECIR, SI NO HAY AMBAS PARTIDAS CONTABLES EN CONJUNTO PARA 2 PERÍODOS o 2 cierres contables en conjunto o años de presentación de los estados financieros. (OJO NO aplica si en un periodo contable o año se reportan cifras DE AL MENOS UNA DE ESTAS PARTIDAS (13 O 14) Y EN OTRO PERIODO CONTABLE NO SE REPORTA NADA O SOLO SE REPORTA UNA DE ELLAS.)</td>
+              <td>1</td>
               <td>proveedores, acreedores</td>
               <td><strong>Proveedores:</strong> ${provAnterior}<br><strong>Acreedores:</strong> ${acreAnterior}</td>
               <td><strong>Proveedores:</strong> ${provPrevio}<br><strong>Acreedores:</strong> ${acrePrevio}</td>
@@ -5768,6 +5770,7 @@ ${JSON.stringify(info_email_error, null, 2)}
             <tr>
               <td>2</td>
               <td style="background-color: #000; color: #fff;">No presenta Ventas (PARTIDA 27) en al menos un cierre contable</td>
+              <td>2</td>
               <td>ventas_anuales</td>
               <td><strong>Valor:</strong> ${ventasAnterior}</td>
               <td><strong>Valor:</strong> ${ventasPrevio}</td>
@@ -5776,6 +5779,7 @@ ${JSON.stringify(info_email_error, null, 2)}
             <tr>
               <td>3</td>
               <td style="background-color: #000; color: #fff;">No presenta Costo de Ventas (PARTIDA 28) en al menos un cierre contable</td>
+              <td>3</td>
               <td>costo_ventas_anuales</td>
               <td><strong>Valor:</strong> ${costoAnterior}</td>
               <td><strong>Valor:</strong> ${costoPrevio}</td>
@@ -5784,6 +5788,7 @@ ${JSON.stringify(info_email_error, null, 2)}
             <tr>
               <td>4</td>
               <td style="background-color: #000; color: #fff;">No presenta Utilidad Bruta (PARTIDA 29) en al menos un cierre contable</td>
+              <td>4</td>
               <td>utilidad_bruta</td>
               <td><strong>Valor:</strong> ${utilidadBrutaAnterior}</td>
               <td><strong>Valor:</strong> ${utilidadBrutaPrevio}</td>
@@ -5791,47 +5796,53 @@ ${JSON.stringify(info_email_error, null, 2)}
             </tr>
             <tr>
               <td>5</td>
-              <td style="background-color: #000; color: #fff;">Si en al menos uno de los dos periodos contables no se tiene registrado un valor para capital contable, se ejecuta el algoritmo sin EEFF.</td>
-              <td>capital_contable</td>
-              <td><strong>Valor:</strong> ${capitalAnterior}</td>
-              <td><strong>Valor:</strong> ${capitalPrevio}</td>
-              <td>${msg(resCapital)}</td>
-            </tr>
-            <tr>
-              <td>6</td>
-              <td style="background-color: #000; color: #fff;">Si en cualquier periodo contable faltan tanto el valor de caja y bancos como el de inventarios, se ejecuta el algoritmo sin EEFF.</td>
-              <td>caja_bancos, saldo_inventarios</td>
-              <td><strong>Caja y bancos:</strong> ${cajaAnterior}<br><strong>Inventarios:</strong> ${invAnterior}</td>
-              <td><strong>Caja y bancos:</strong> ${cajaPrevio}<br><strong>Inventarios:</strong> ${invPrevio}</td>
-              <td>${msgCajaInv(resCajaInv)}</td>
-            </tr>
-            <tr>
-              <td>7</td>
-              <td style="background-color: #000; color: #fff;">Si en cualquier periodo contable faltan tanto el valor de clientes y cuentas por cobrar como el de inventarios, se ejecuta el algoritmo sin EEFF.</td>
-              <td>saldo_cliente_cuenta_x_cobrar, saldo_inventarios</td>
-              <td><strong>Clientes y ctas x cobrar:</strong> ${cxcAnterior}<br><strong>Inventarios:</strong> ${invAnterior}</td>
-              <td><strong>Clientes y ctas x cobrar:</strong> ${cxcPrevio}<br><strong>Inventarios:</strong> ${invPrevio}</td>
-              <td>${msg(resClientesInv)}</td>
-            </tr>
-            <tr>
-              <td>8</td>
-              <td style="background-color: #000; color: #fff;">Proveedores sin datos en ambos periodos</td>
-              <td>proveedores</td>
-              <td><strong>Valor:</strong> ${provAnterior}</td>
-              <td><strong>Valor:</strong> ${provPrevio}</td>
-              <td>${msg(resProveedores)}</td>
-            </tr>
-            <tr>
-              <td>9</td>
-              <td style="background-color: #000; color: #fff;">Utilidad operativa no reportada en al menos un periodo</td>
+              <td style="background-color: #000; color: #fff;">No presenta Utilidad Operativa (PARTIDA 31) en al menos un cierre contable</td>
+              <td>5</td>
               <td>utilidad_operativa</td>
               <td><strong>Valor:</strong> ${utilidadOperativaAnterior}</td>
               <td><strong>Valor:</strong> ${utilidadOperativaPrevio}</td>
               <td>${msg(resUOperativa)}</td>
             </tr>
             <tr>
+              <td>6</td>
+              <td style="background-color: #000; color: #fff;">Si en al menos uno de los dos periodos contables no se tiene registrado un valor para capital contable, se ejecuta el algoritmo sin EEFF.</td>
+              <td>6</td>
+              <td>capital_contable</td>
+              <td><strong>Valor:</strong> ${capitalAnterior}</td>
+              <td><strong>Valor:</strong> ${capitalPrevio}</td>
+              <td>${msg(resCapital)}</td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td style="background-color: #000; color: #fff;">Si en cualquier periodo contable faltan tanto el valor de caja y bancos como el de inventarios, se ejecuta el algoritmo sin EEFF.</td>
+              <td>7</td>
+              <td>caja_bancos, saldo_inventarios</td>
+              <td><strong>Caja y bancos:</strong> ${cajaAnterior}<br><strong>Inventarios:</strong> ${invAnterior}</td>
+              <td><strong>Caja y bancos:</strong> ${cajaPrevio}<br><strong>Inventarios:</strong> ${invPrevio}</td>
+              <td>${msgCajaInv(resCajaInv)}</td>
+            </tr>
+            <tr>
+              <td>8</td>
+              <td style="background-color: #000; color: #fff;">Si en cualquier periodo contable faltan tanto el valor de clientes y cuentas por cobrar como el de inventarios, se ejecuta el algoritmo sin EEFF.</td>
+              <td>8</td>
+              <td>saldo_cliente_cuenta_x_cobrar, saldo_inventarios</td>
+              <td><strong>Clientes y ctas x cobrar:</strong> ${cxcAnterior}<br><strong>Inventarios:</strong> ${invAnterior}</td>
+              <td><strong>Clientes y ctas x cobrar:</strong> ${cxcPrevio}<br><strong>Inventarios:</strong> ${invPrevio}</td>
+              <td>${msg(resClientesInv)}</td>
+            </tr>
+            <tr>
+              <td>9</td>
+              <td style="background-color: #000; color: #fff;">Proveedores sin datos en ambos periodos</td>
+              <td>9</td>
+              <td>proveedores</td>
+              <td><strong>Valor:</strong> ${provAnterior}</td>
+              <td><strong>Valor:</strong> ${provPrevio}</td>
+              <td>${msg(resProveedores)}</td>
+            </tr>
+            <tr>
               <td>10</td>
               <td style="background-color: #000; color: #fff;">Utilidad neta no reportada en al menos un periodo</td>
+              <td>10</td>
               <td>utilidad_neta</td>
               <td><strong>Valor:</strong> ${utilidadNetaAnterior}</td>
               <td><strong>Valor:</strong> ${utilidadNetaPrevio}</td>


### PR DESCRIPTION
## Summary
- update the table sent by `sendEmailNodeMailer` with an extra column for numbering
- reorder rules so the missing `Utilidad Operativa` check appears in the fifth spot

## Testing
- `node --check src/controllers/api/certification.js`


------
https://chatgpt.com/codex/tasks/task_e_685ae0ace16c832da0f3a6c112607987