### PR TITLE
Add BlocService for API centralization

### DIFF
--- a/BD/bloc_responses.sql
+++ b/BD/bloc_responses.sql
@@ -1,0 +1,10 @@
+CREATE TABLE bloc_responses (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    request_json LONGTEXT,
+    endpoint_name VARCHAR(100) NOT NULL,
+    request_url TEXT,
+    http_status SMALLINT,
+    response_time_ms INT,
+    response_json LONGTEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;

--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -14,6 +14,7 @@ const companiesService = require('../../services/companies')
 const paymentsService = require('../../services/payments')
 const hadesService = require('../../services/hades')
 const algorithmService = require('../../services/algorithm')
+const blocService = require('../../services/bloc')
 const cronosTypes = { certification: 'Certification', report: 'Report' }
 const uploadImageS3 = require('../../utils/uploadImageS3')
 const logger = require('../../utils/logs/logger')
@@ -4380,47 +4381,7 @@ const validacionBloc = async (req, res, next) => {
 }
 
 const consultaBlocEmpresaControlanteData = async (nombre, apellido = '') => {
-  const params = await utilitiesService.getParametros()
-
-  const getUrl = (param) => {
-    const conf = params.find(item => item.nombre === param)
-    return conf ? conf.valor : null
-  }
-
-  const sat69bUrl = getUrl('block_lista_sat_69B_presuntos_inexistentes')
-    ?.replace('||', encodeURIComponent(nombre))
-    .replace('||', encodeURIComponent(apellido))
-
-  const ofacUrl = getUrl('bloc_ofac')
-    ?.replace('||', encodeURIComponent(nombre))
-    .replace('||', encodeURIComponent(apellido))
-
-  const concursosUrl = getUrl('bloc_consursos_mercantiles')
-    ?.replace('||', encodeURIComponent(nombre))
-
-  const proveedoresUrl = getUrl('bloc_provedores_contratistas')
-    ?.replace('||', encodeURIComponent(nombre))
-    .replace('||', encodeURIComponent(apellido))
-
-  const requests = [
-    sat69bUrl ? axios.get(sat69bUrl) : Promise.resolve({ data: null }),
-    ofacUrl ? axios.get(ofacUrl) : Promise.resolve({ data: null }),
-    concursosUrl ? axios.get(concursosUrl) : Promise.resolve({ data: null }),
-    proveedoresUrl ? axios.get(proveedoresUrl) : Promise.resolve({ data: null })
-  ]
-
-  const results = await Promise.allSettled(requests)
-
-  const [sat69bResp, ofacResp, concursosResp, proveedoresResp] = results.map(r =>
-    r.status === 'fulfilled' ? r.value : { data: null }
-  )
-
-  return {
-    bloc_sat69b: sat69bResp.data,
-    bloc_ofac: ofacResp.data,
-    bloc_concursos_mercantiles: concursosResp.data,
-    bloc_proveedores_contratistas: proveedoresResp.data
-  }
+  return blocService.callAll(nombre, apellido)
 }
 
 const consultaBlocEmpresaControlante = async (req, res, next) => {

--- a/src/services/bloc.js
+++ b/src/services/bloc.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const axios = require('axios')
+const mysqlLib = require('../lib/db')
+const utilitiesService = require('./utilities')
+const logger = require('../utils/logs/logger')
+
+class BlocService {
+  constructor () {
+    if (BlocService.instance == null) {
+      this.table = 'bloc_responses'
+      this.params = null
+      BlocService.instance = this
+    }
+    return BlocService.instance
+  }
+
+  async loadConfig () {
+    try {
+      this.params = await utilitiesService.getParametros()
+    } catch (err) {
+      logger.error(`BlocService loadConfig error: ${err.message}`)
+      this.params = null
+    }
+  }
+
+  getParamValue (name) {
+    if (!this.params) return null
+    const conf = this.params.find(item => item.nombre === name)
+    return conf ? conf.valor : null
+  }
+
+  async saveBlocResponse ({ request_json = null, endpoint_name, request_url = null, http_status = null, response_time_ms = null, response_json = null }) {
+    const queryString = `INSERT INTO ${this.table} (
+        request_json,
+        endpoint_name,
+        request_url,
+        http_status,
+        response_time_ms,
+        response_json
+      ) VALUES (
+        ${request_json ? mysqlLib.escape(request_json) : 'NULL'},
+        ${mysqlLib.escape(endpoint_name)},
+        ${request_url ? mysqlLib.escape(request_url) : 'NULL'},
+        ${http_status ?? 'NULL'},
+        ${response_time_ms ?? 'NULL'},
+        ${response_json ? mysqlLib.escape(response_json) : 'NULL'}
+      )`
+    const { result } = await mysqlLib.query(queryString)
+    return result
+  }
+
+  async callEndpoint ({ paramName, endpointName, replacements = [], requestData = null }) {
+    if (!this.params) await this.loadConfig()
+
+    const template = this.getParamValue(paramName)
+    if (!template) return { data: null }
+
+    let url = template
+    for (const rep of replacements) {
+      url = url.replace('||', encodeURIComponent(rep))
+    }
+
+    const startTs = Date.now()
+    let response
+    let status
+    try {
+      response = await axios.get(url)
+      status = response.status
+    } catch (err) {
+      status = err.response ? err.response.status : null
+      response = { data: null }
+    }
+    const responseTime = Date.now() - startTs
+
+    try {
+      await this.saveBlocResponse({
+        request_json: requestData ? JSON.stringify(requestData) : null,
+        endpoint_name: endpointName,
+        request_url: url,
+        http_status: status,
+        response_time_ms: responseTime,
+        response_json: response ? JSON.stringify(response.data) : null
+      })
+    } catch (err) {
+      logger.error(`Error saving bloc response: ${err.message}`)
+    }
+
+    return response
+  }
+
+  async callAll (nombre, apellido = '') {
+    const endpoints = [
+      { param: 'block_lista_sat_69B_presuntos_inexistentes', name: 'sat69b', reps: [nombre, apellido] },
+      { param: 'bloc_ofac', name: 'ofac', reps: [nombre, apellido] },
+      { param: 'bloc_consursos_mercantiles', name: 'concursos_mercantiles', reps: [nombre] },
+      { param: 'bloc_provedores_contratistas', name: 'proveedores_contratistas', reps: [nombre, apellido] }
+    ]
+    const reqs = endpoints.map(e => this.callEndpoint({ paramName: e.param, endpointName: e.name, replacements: e.reps }))
+    const results = await Promise.allSettled(reqs)
+
+    const [sat69b, ofac, concursos, proveedores] = results.map(r =>
+      r.status === 'fulfilled' ? r.value : { data: null }
+    )
+
+    return {
+      bloc_sat69b: sat69b.data,
+      bloc_ofac: ofac.data,
+      bloc_concursos_mercantiles: concursos.data,
+      bloc_proveedores_contratistas: proveedores.data
+    }
+  }
+}
+
+module.exports = Object.freeze(new BlocService())


### PR DESCRIPTION
## Summary
- create `bloc_responses` table definition
- add a dedicated Bloc service to centralize API calls and log responses
- use BlocService in certification controller

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aedbe18a4832da08d72e86538fb9d