### PR TITLE
Hide Score V2 in País table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6781,25 +6781,27 @@ ${JSON.stringify(info_email_error, null, 2)}
               const opcion = opt.nombre ?? opt.descripcion ?? '-'
               const isSel = selected && opcion.toLowerCase() === selected
               const opcionHtml = isSel ? `<strong>${opcion}</strong>` : opcion
+              const scoreColumn = table === 'cat_pais_algoritmo'
+                ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`
+                : `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td><td style="padding: 4px 6px; border: 1px solid #ccc;">${v2}</td>`
               return `
                 <tr style="background-color:${idx % 2 === 0 ? '#ffffff' : '#f5f5f5'};">
-                  <td style="padding: 6px 8px; border: 1px solid #ddd;">${opcionHtml}</td>
-                  <td style="padding: 6px 8px; border: 1px solid #ddd;">${v1}</td>
-                  <td style="padding: 6px 8px; border: 1px solid #ddd;">${v2}</td>
+                  <td style="padding: 4px 6px; border: 1px solid #ccc;">${opcionHtml}</td>
+                  ${scoreColumn}
                 </tr>`
             })
             .join('')
-          const rows = rowItems || `<tr><td colspan="3" style="padding: 6px 8px; border: 1px solid #ddd; text-align: center;">No hay información disponible</td></tr>`
+          const colSpan = table === 'cat_pais_algoritmo' ? 2 : 3
+          const rows = rowItems || `<tr><td colspan="${colSpan}" style="padding: 4px 6px; border: 1px solid #ccc; text-align: center;">No hay información disponible</td></tr>`
+          const header = table === 'cat_pais_algoritmo'
+            ? `<tr><th>Opción</th><th>Score</th></tr>`
+            : `<tr><th>Opción</th><th>Score V1</th><th>Score V2</th></tr>`
           return `
             <div class="table-section">
-            <table border="1" cellspacing="0" cellpadding="6" style="border-collapse: collapse; width: 100%; font-family: Arial, Helvetica, sans-serif; font-size: 10px;">
+            <table border="1" cellspacing="0" cellpadding="4" style="border-collapse: collapse; width: auto; margin: 0 auto; font-family: 'Segoe UI', Arial, sans-serif; font-size: 9px;">
               <caption>${label} (tabla: ${table})</caption>
-              <thead style="background-color: #f2f2f2;">
-                <tr>
-                  <th>Opción</th>
-                  <th>Score V1</th>
-                  <th>Score V2</th>
-                </tr>
+              <thead style="background-color: #003366; color: #fff;">
+                ${header}
               </thead>
               <tbody>
                 ${rows}


### PR DESCRIPTION
## Summary
- tweak sendEmailNodeMailer to remove `Score V2` from the País table
- rename `Score V1` column to `Score`
- refine table styling for better readability

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b0492cf34832dbeef8c33794f3e74