### PR TITLE
Refactor number parsing helpers

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -20,6 +20,7 @@ const uploadImageS3 = require('../../utils/uploadImageS3')
 const logger = require('../../utils/logs/logger')
 const cipher = require('../../utils/cipherService')
 const nodemailer = require('nodemailer')
+const { toNumber, getLimits } = require('../../utils/numberUtils')
 
 const { sendCompaniEmail } = require('./mailjet-controler')
 
@@ -2775,29 +2776,7 @@ const getScoreEvolucionVentasFromSummary = async (
       evolucion_ventas: evolucion
     }
 
-    const toNumber = (val) => {
-      if (val === undefined || val === null) return NaN
-      const str = String(val).trim().toLowerCase()
-      if (str === 'inf') return Infinity
-      if (str === '-inf') return -Infinity
-      const clean = str.replace(/[^0-9.-]/g, '')
-      return parseFloat(clean)
-    }
-
-    const getLimits = (entry) => {
-      if (entry.limite_inferior !== undefined && entry.limite_inferior !== null) {
-        const inf = toNumber(entry.limite_inferior)
-        const sup = entry.limite_superior == null ? Infinity : toNumber(entry.limite_superior)
-        return [inf, sup]
-      }
-      if (entry.rango) {
-        const [a, b] = entry.rango.replace(/[()\[\]]/g, '').split(',')
-        const start = toNumber(a)
-        const end = toNumber(b)
-        return [Math.min(start, end), Math.max(start, end)]
-      }
-      return [NaN, NaN]
-    }
+    
 
     const evoScore = parametrosAlgoritmo.evolucionVentasScore.find(e => {
       const [inf, sup] = getLimits(e)
@@ -2887,29 +2866,7 @@ const getScoreApalancamientoFromSummary = async (
       }
     }
 
-    const toNumber = (val) => {
-      if (val === undefined || val === null) return NaN
-      const str = String(val).trim().toLowerCase()
-      if (str === 'inf') return Infinity
-      if (str === '-inf') return -Infinity
-      const clean = str.replace(/[^0-9.-]/g, '')
-      return parseFloat(clean)
-    }
 
-    const getLimits = (entry) => {
-      if (entry.limite_inferior !== undefined && entry.limite_inferior !== null) {
-        const inf = toNumber(entry.limite_inferior)
-        const sup = entry.limite_superior == null ? Infinity : toNumber(entry.limite_superior)
-        return [inf, sup]
-      }
-      if (entry.rango) {
-        const [a, b] = entry.rango.replace(/[()\[\]]/g, '').split(',')
-        const start = toNumber(a)
-        const end = toNumber(b)
-        return [Math.min(start, end), Math.max(start, end)]
-      }
-      return [NaN, NaN]
-    }
 
     const apalScore = parametrosAlgoritmo.apalancamientoScore.find(a => {
       const [inf, sup] = getLimits(a)
@@ -2948,29 +2905,7 @@ const getScoreCajaBancosFromSummary = async (
     const cajaBancoPCA = await certificationService.cajaBancoPCA(id_certification)
     if (!cajaBancoPCA) return { error: true }
 
-    const toNumber = (val) => {
-      if (val === undefined || val === null) return NaN
-      const str = String(val).trim().toLowerCase()
-      if (str === 'inf') return Infinity
-      if (str === '-inf') return -Infinity
-      const clean = str.replace(/[^0-9.-]/g, '')
-      return parseFloat(clean)
-    }
 
-    const getLimits = (entry) => {
-      if (entry.limite_inferior !== undefined && entry.limite_inferior !== null) {
-        const inf = toNumber(entry.limite_inferior)
-        const sup = entry.limite_superior == null ? Infinity : toNumber(entry.limite_superior)
-        return [inf, sup]
-      }
-      if (entry.rango) {
-        const [a, b] = entry.rango.replace(/[()\[\]]/g, '').split(',')
-        const start = toNumber(a)
-        const end = toNumber(b)
-        return [Math.min(start, end), Math.max(start, end)]
-      }
-      return [NaN, NaN]
-    }
 
     const cajaScore = parametrosAlgoritmo.flujoNetoScore.find(c => {
       const [inf, sup] = getLimits(c)

--- a/src/utils/numberUtils.js
+++ b/src/utils/numberUtils.js
@@ -1,0 +1,27 @@
+'use strict'
+
+function toNumber(val) {
+  if (val === undefined || val === null) return NaN
+  const str = String(val).trim().toLowerCase()
+  if (str === 'inf') return Infinity
+  if (str === '-inf') return -Infinity
+  const clean = str.replace(/[^0-9.-]/g, '')
+  return parseFloat(clean)
+}
+
+function getLimits(entry) {
+  if (entry.limite_inferior !== undefined && entry.limite_inferior !== null) {
+    const inf = toNumber(entry.limite_inferior)
+    const sup = entry.limite_superior == null ? Infinity : toNumber(entry.limite_superior)
+    return [inf, sup]
+  }
+  if (entry.rango) {
+    const [a, b] = entry.rango.replace(/[()\[\]]/g, '').split(',')
+    const start = toNumber(a)
+    const end = toNumber(b)
+    return [Math.min(start, end), Math.max(start, end)]
+  }
+  return [NaN, NaN]
+}
+
+module.exports = { toNumber, getLimits }


### PR DESCRIPTION
## Summary
- add `toNumber` and `getLimits` utilities
- replace duplicate nested helpers in `certification.js` with shared utils

## Testing
- `node -e "require('./src/utils/numberUtils')"`
- `node --check src/controllers/api/certification.js`

------
https://chatgpt.com/codex/tasks/task_e_685b0d2c10b8832d9df73cb8d27f498c