### PR TITLE
Remove hardcoded fallback score

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -4016,6 +4016,17 @@ WHERE cer.certificacion_id = (
     return result[0]
   }
 
+  async getDefaultRotacionScore() {
+    const queryString = `
+      SELECT nombre, valor_algoritmo, limite_inferior, limite_superior
+      FROM cat_rotacion_cuentas_cobrar_algoritmo
+      ORDER BY valor_algoritmo ASC
+      LIMIT 1;
+    `
+    const { result } = await mysqlLib.query(queryString)
+    return result[0]
+  }
+
 
   async getClass(value) {
 


### PR DESCRIPTION
## Summary
- fetch default rotación score from DB when DSO/DIO are missing
- add service helper for retrieving minimal rotación score

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b22205e88832d8a8e773093450cac