### PR TITLE
Fix apalancamiento data mismatch

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3586,7 +3586,9 @@ WHERE cer.certificacion_id = (
     FROM certification_partidas_estado_balance
     WHERE
       tipo = 'anterior'
-      AND id_certification = ${id};
+      AND id_certification = ${id}
+    ORDER BY id_certification_partidas_estado_balance DESC
+    LIMIT 1;
     `
     const { result } = await mysqlLib.query(queryString)
     return result[0]
@@ -3604,7 +3606,9 @@ WHERE cer.certificacion_id = (
     FROM certification_partidas_estado_balance
     WHERE
       tipo = 'anterior'
-      AND id_certification = ${id};
+      AND id_certification = ${id}
+    ORDER BY id_certification_partidas_estado_balance DESC
+    LIMIT 1;
     `
     const { result } = await mysqlLib.query(queryString)
     return result[0]
@@ -3622,7 +3626,9 @@ WHERE cer.certificacion_id = (
     FROM certification_partidas_estado_balance
     WHERE
       tipo = 'anterior'
-      AND id_certification = ${id};
+      AND id_certification = ${id}
+    ORDER BY id_certification_partidas_estado_balance DESC
+    LIMIT 1;
     `
     const { result } = await mysqlLib.query(queryString)
     return result[0]


### PR DESCRIPTION
## Summary
- order balance queries by descending id to always fetch the most recent period

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: could not download package)*

------
https://chatgpt.com/codex/tasks/task_e_685b3588f7d4832db1d5f4d3fe3115b2