### PR TITLE
Fix Tiempo Actividad table columns for PDF

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6803,7 +6803,7 @@ ${JSON.stringify(info_email_error, null, 2)}
               const opcion = opt.nombre ?? opt.descripcion ?? '-'
               const isSel = selected && opcion.toLowerCase() === selected
               const opcionHtml = isSel ? `<strong>${opcion}</strong>` : opcion
-              const singleScoreTables = ['cat_pais_algoritmo', 'cat_capital_contable_algoritmo']
+              const singleScoreTables = ['cat_pais_algoritmo', 'cat_capital_contable_algoritmo', 'cat_tiempo_actividad_comercial_algoritmo']
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`
                 : `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td><td style="padding: 4px 6px; border: 1px solid #ccc;">${v2}</td>`


### PR DESCRIPTION
## Summary
- adjust reference table logic so `cat_tiempo_actividad_comercial_algoritmo` only renders one score column

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b47cce454832d99a53b7df7964c8d