### PR TITLE
Remove Score V2 for Influencia Controlante in PDF

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6803,7 +6803,7 @@ ${JSON.stringify(info_email_error, null, 2)}
               const opcion = opt.nombre ?? opt.descripcion ?? '-'
               const isSel = selected && opcion.toLowerCase() === selected
               const opcionHtml = isSel ? `<strong>${opcion}</strong>` : opcion
-              const singleScoreTables = ['cat_pais_algoritmo', 'cat_capital_contable_algoritmo']
+              const singleScoreTables = ['cat_pais_algoritmo', 'cat_capital_contable_algoritmo', 'cat_influencia_controlante']
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`
                 : `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td><td style="padding: 4px 6px; border: 1px solid #ccc;">${v2}</td>`


### PR DESCRIPTION
## Summary
- update score table generation to treat `cat_influencia_controlante` as a single score table so the PDF sent via NodeMailer no longer shows the `Score V2` column

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b4844eef4832da06ab7eddfe6bbfe