### PR TITLE
Fix Evolución Ventas PDF column

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6803,7 +6803,7 @@ ${JSON.stringify(info_email_error, null, 2)}
               const opcion = opt.nombre ?? opt.descripcion ?? '-'
               const isSel = selected && opcion.toLowerCase() === selected
               const opcionHtml = isSel ? `<strong>${opcion}</strong>` : opcion
-              const singleScoreTables = ['cat_pais_algoritmo', 'cat_capital_contable_algoritmo', 'cat_tiempo_actividad_comercial_algoritmo']
+              const singleScoreTables = ['cat_pais_algoritmo', 'cat_capital_contable_algoritmo', 'cat_tiempo_actividad_comercial_algoritmo', 'cat_evolucion_ventas_algoritmo']
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`
                 : `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td><td style="padding: 4px 6px; border: 1px solid #ccc;">${v2}</td>`


### PR DESCRIPTION
## Summary
- remove the Score V2 column for `cat_evolucion_ventas_algoritmo` tables in nodemailer PDF

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b4906ea24832d8a91b28cf3682644