### PR TITLE
Remove extra score column for rotacion ctas table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6803,7 +6803,12 @@ ${JSON.stringify(info_email_error, null, 2)}
               const opcion = opt.nombre ?? opt.descripcion ?? '-'
               const isSel = selected && opcion.toLowerCase() === selected
               const opcionHtml = isSel ? `<strong>${opcion}</strong>` : opcion
-              const singleScoreTables = ['cat_pais_algoritmo', 'cat_capital_contable_algoritmo', 'cat_tiempo_actividad_comercial_algoritmo']
+              const singleScoreTables = [
+                'cat_pais_algoritmo',
+                'cat_capital_contable_algoritmo',
+                'cat_tiempo_actividad_comercial_algoritmo',
+                'cat_rotacion_cuentas_cobrar_algoritmo'
+              ]
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`
                 : `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td><td style="padding: 4px 6px; border: 1px solid #ccc;">${v2}</td>`


### PR DESCRIPTION
## Summary
- remove Score V2 column for `cat_rotacion_cuentas_cobrar_algoritmo` table in the certification PDF generator

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b499f8004832db92379be25f3f29c