### PR TITLE
Fix extra header for rotation table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6814,8 +6814,7 @@ ${JSON.stringify(info_email_error, null, 2)}
               const singleScoreTables = [
                 'cat_pais_algoritmo',
                 'cat_capital_contable_algoritmo',
-                'cat_tiempo_actividad_comercial_algoritmo',
-                'cat_rotacion_cuentas_cobrar_algoritmo'
+                'cat_tiempo_actividad_comercial_algoritmo'
               ]
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`


### PR DESCRIPTION
## Summary
- fix singleScoreTables inner reference in certification email report

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b4c0ebd1c832da0e3250d0a89f8c7