### PR TITLE
Remove Score V2 from Ventas Anuales table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6798,7 +6798,8 @@ ${JSON.stringify(info_email_error, null, 2)}
         'cat_capital_contable_algoritmo',
         'cat_tiempo_actividad_comercial_algoritmo',
         'cat_apalancamiento_algoritmo',
-        'cat_flujo_neto_caja_algoritmo'
+        'cat_flujo_neto_caja_algoritmo',
+        'cat_ventas_anuales_algoritmo'
       ]
 
       const referenceTables = variablesReference
@@ -6814,7 +6815,8 @@ ${JSON.stringify(info_email_error, null, 2)}
               const singleScoreTables = [
                 'cat_pais_algoritmo',
                 'cat_capital_contable_algoritmo',
-                'cat_tiempo_actividad_comercial_algoritmo'
+                'cat_tiempo_actividad_comercial_algoritmo',
+                'cat_ventas_anuales_algoritmo'
               ]
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`


### PR DESCRIPTION
## Summary
- update nodemailer PDF to omit the Score V2 column in the Ventas Anuales table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b51b1b98c832d83577362aec35f72