### PR TITLE
Remove Score V2 column for tipo cifras

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6799,7 +6799,8 @@ ${JSON.stringify(info_email_error, null, 2)}
         'cat_tiempo_actividad_comercial_algoritmo',
         'cat_apalancamiento_algoritmo',
         'cat_flujo_neto_caja_algoritmo',
-        'cat_ventas_anuales_algoritmo'
+        'cat_ventas_anuales_algoritmo',
+        'cat_tipo_cifras_algoritmo'
       ]
 
       const referenceTables = variablesReference
@@ -6816,7 +6817,8 @@ ${JSON.stringify(info_email_error, null, 2)}
                 'cat_pais_algoritmo',
                 'cat_capital_contable_algoritmo',
                 'cat_tiempo_actividad_comercial_algoritmo',
-                'cat_ventas_anuales_algoritmo'
+                'cat_ventas_anuales_algoritmo',
+                'cat_tipo_cifras_algoritmo'
               ]
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`


### PR DESCRIPTION
## Summary
- update certification PDF email to treat `cat_tipo_cifras_algoritmo` as a single score table

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b5314e968832da9fbfcb8dc85869f