### PR TITLE
Remove Score V2 column from apalancamiento table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6818,6 +6818,7 @@ ${JSON.stringify(info_email_error, null, 2)}
                 'cat_pais_algoritmo',
                 'cat_capital_contable_algoritmo',
                 'cat_tiempo_actividad_comercial_algoritmo',
+                'cat_apalancamiento_algoritmo',
                 'cat_ventas_anuales_algoritmo',
                 'cat_tipo_cifras_algoritmo',
                 'cat_evolucion_ventas_algoritmo'


### PR DESCRIPTION
## Summary
- fix PDF generator to treat `cat_apalancamiento_algoritmo` as a single-score table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b553c33a8832d9f6a4c07bf8c9411