### PR TITLE
Fix flujo neto pdf table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6819,6 +6819,7 @@ ${JSON.stringify(info_email_error, null, 2)}
                 'cat_capital_contable_algoritmo',
                 'cat_tiempo_actividad_comercial_algoritmo',
                 'cat_apalancamiento_algoritmo',
+                'cat_flujo_neto_caja_algoritmo',
                 'cat_ventas_anuales_algoritmo',
                 'cat_tipo_cifras_algoritmo',
                 'cat_evolucion_ventas_algoritmo'


### PR DESCRIPTION
## Summary
- update certification PDF generator to treat `cat_flujo_neto_caja_algoritmo` as a single score table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b579f5828832da210030603cc5e53