### PR TITLE
Remove Score V2 from Payback table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6801,7 +6801,8 @@ ${JSON.stringify(info_email_error, null, 2)}
         'cat_flujo_neto_caja_algoritmo',
         'cat_ventas_anuales_algoritmo',
         'cat_tipo_cifras_algoritmo',
-        'cat_evolucion_ventas_algoritmo'
+        'cat_evolucion_ventas_algoritmo',
+        'cat_payback_algoritmo'
       ]
 
       const referenceTables = variablesReference
@@ -6822,7 +6823,8 @@ ${JSON.stringify(info_email_error, null, 2)}
                 'cat_flujo_neto_caja_algoritmo',
                 'cat_ventas_anuales_algoritmo',
                 'cat_tipo_cifras_algoritmo',
-                'cat_evolucion_ventas_algoritmo'
+                'cat_evolucion_ventas_algoritmo',
+                'cat_payback_algoritmo'
               ]
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`


### PR DESCRIPTION
## Summary
- update generation of algorithm PDF so that the Payback table only shows a single score column

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b58626e3c832d8451548e82549bf2