### PR TITLE
Fix PDF column for accounts receivable rotation

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6802,7 +6802,8 @@ ${JSON.stringify(info_email_error, null, 2)}
         'cat_ventas_anuales_algoritmo',
         'cat_tipo_cifras_algoritmo',
         'cat_evolucion_ventas_algoritmo',
-        'cat_payback_algoritmo'
+        'cat_payback_algoritmo',
+        'cat_rotacion_cuentas_cobrar_algoritmo'
       ]
 
       const referenceTables = variablesReference
@@ -6824,7 +6825,8 @@ ${JSON.stringify(info_email_error, null, 2)}
                 'cat_ventas_anuales_algoritmo',
                 'cat_tipo_cifras_algoritmo',
                 'cat_evolucion_ventas_algoritmo',
-                'cat_payback_algoritmo'
+                'cat_payback_algoritmo',
+                'cat_rotacion_cuentas_cobrar_algoritmo'
               ]
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`


### PR DESCRIPTION
## Summary
- remove V2 score column from Rotación ctas x cobrar table in algorithm report PDF

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b58fd1918832d9c60f6d17be571a9