### PR TITLE
Fix service call for deleting referencias comerciales

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -1345,7 +1345,7 @@ const guardaReferenciasComerciales = async (req, res, next) => {
     }
     logger.warn(`${fileMethod} | Se obtiene la certificación a las cuales se van a vincular las referencias comerciales ${JSON.stringify(certificacionIniciada)}`)
 
-    await certificationService.deleteReferenciaComercial(id_certification);
+    await certificationService.deleteReferenciasComerciales(id_certification);
     for (const referencia of referencias_comerciales) {
       const existe = await certificationService.existeReferenciaComercial(
         referencia.id_certification_referencia_comercial


### PR DESCRIPTION
## Summary
- correct misnamed service method in certification controller

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c1ea219e0832da1d0c92c5f1b74db