### PR TITLE
Log Bloc API configuration errors

### DIFF
--- a/BD/bloc_responses.sql
+++ b/BD/bloc_responses.sql
@@ -6,5 +6,6 @@ CREATE TABLE bloc_responses (
     http_status SMALLINT,
     response_time_ms INT,
     response_json LONGTEXT,
+    error_message TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;


### PR DESCRIPTION
## Summary
- add `error_message` column to `bloc_responses`
- record configuration errors in `callEndpoint`
- update `saveBlocResponse` to persist `error_message`

## Testing
- `node -v`
- `npm -v`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c3130bdb4832d8b5e49412430ae05