### PR TITLE
Add centralized BLOC controller and expose responses

### DIFF
--- a/src/controllers/api/bloc.js
+++ b/src/controllers/api/bloc.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const blocService = require('../../services/bloc')
+const logger = require('../../utils/logs/logger')
+
+const callAllBlocServices = async (nombre, apellido = '') => {
+  const fileMethod = `file: src/controllers/api/bloc.js - method: callAllBlocServices`
+  try {
+    const data = await blocService.callAll(nombre, apellido)
+    return data
+  } catch (error) {
+    logger.error(`${fileMethod} | Error durante la consulta a BLOC: ${JSON.stringify(error)}`)
+    throw error
+  }
+}
+
+module.exports = {
+  callAllBlocServices
+}

--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -15,6 +15,7 @@ const paymentsService = require('../../services/payments')
 const hadesService = require('../../services/hades')
 const algorithmService = require('../../services/algorithm')
 const blocService = require('../../services/bloc')
+const blocController = require('./bloc')
 const cronosTypes = { certification: 'Certification', report: 'Report' }
 const uploadImageS3 = require('../../utils/uploadImageS3')
 const logger = require('../../utils/logs/logger')
@@ -4105,7 +4106,7 @@ const validacionBloc = async (req, res, next) => {
       bloc_ofac,
       bloc_concursos_mercantiles,
       bloc_proveedores_contratistas
-    } = await blocService.callAll(nombre, apellido)
+    } = await blocController.callAllBlocServices(nombre, apellido)
 
     if (bloc_sat69b) {
       const data_block_lista_sat_69B_presuntos_inexistentes = bloc_sat69b
@@ -4183,7 +4184,11 @@ const validacionBloc = async (req, res, next) => {
     return res.json({
       sin_incidencias,
       message,
-      asunto
+      asunto,
+      bloc_sat69b,
+      bloc_ofac,
+      bloc_concursos_mercantiles,
+      bloc_proveedores_contratistas
     })
 
   } catch (error) {


### PR DESCRIPTION
## Summary
- centralize BLOC service calls in new `bloc.js` controller
- use the new controller from `validacionBloc`
- return the raw BLOC responses from the endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_685c4adc2fc4832dbe2a88a7dd606651