### PR TITLE
Fix OpenAPI YAML description quoting

### DIFF
--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -1059,7 +1059,7 @@ router.post('/generaReporteInformativoCredito', /*decryptMiddleware, authMiddlew
  *                 example: ""
  *               rfc:
  *                 type: string
- *                 description: El RFC que se valida. Formato: 3 o 4 letras, 6 dígitos y 3 caracteres alfanuméricos.
+ *                 description: "El RFC que se valida. Formato: 3 o 4 letras, 6 dígitos y 3 caracteres alfanuméricos."
  *                 example: "AAA100303L51"
  *     responses:
  *       200:


### PR DESCRIPTION
## Summary
- fix YAML parse error in `src/routes/api/certification.js` by quoting a description string that contained colons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c54d6d674832d970b4e241c5d9b62