### PR TITLE
Remove RFC requirement from validacionBloc

### DIFF
--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1175,7 +1175,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{}"
+              "raw": "{\n  \"nombre\": \"\",\n  \"apellido\": \"\"\n}"
             }
           }
         },

--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -4093,13 +4093,11 @@ const validacionBloc = async (req, res, next) => {
   const fileMethod = `file: src/controllers/api/certification.js - method: validacionBloc`
   try {
     const { body } = req;
-    const { nombre, apellido, rfc } = body
+    const { nombre, apellido } = body
 
     let sin_incidencias = true
-    let message = 'RFC sin problemas'
+    let message = 'Sin incidencias'
     const asunto = []
-
-    const id_certification = await certificationService.getLastIdCertificationByRfc(rfc)
 
     const {
       bloc_sat69b,
@@ -4112,19 +4110,16 @@ const validacionBloc = async (req, res, next) => {
 
     if (bloc_sat69b) {
       const data_block_lista_sat_69B_presuntos_inexistentes = bloc_sat69b
-      if (Array.isArray(data_block_lista_sat_69B_presuntos_inexistentes.inexistentes) && data_block_lista_sat_69B_presuntos_inexistentes.inexistentes.length > 0) {
-        const rfcEncontrado = data_block_lista_sat_69B_presuntos_inexistentes.inexistentes.find(inexistentes => inexistentes.rfc === rfc)
-        if (rfcEncontrado) {
-          sin_incidencias = false
-          message = 'RFC con problemas'
-          asunto.push({
-            listado69bInexistentes: data_block_lista_sat_69B_presuntos_inexistentes.inexistentes
-          })
-          logger.info(`${fileMethod} | Lista 69B response: ${JSON.stringify(data_block_lista_sat_69B_presuntos_inexistentes.inexistentes)}`)
-
-          const guarda_bloc_69b = await certificationService.guardaBloc_sat69b(id_certification, data_block_lista_sat_69B_presuntos_inexistentes.inexistentes)
-          logger.info(`${fileMethod} | Lista 69B guardado: ${JSON.stringify(guarda_bloc_69b)}`)
-        }
+      if (
+        Array.isArray(data_block_lista_sat_69B_presuntos_inexistentes.inexistentes) &&
+        data_block_lista_sat_69B_presuntos_inexistentes.inexistentes.length > 0
+      ) {
+        sin_incidencias = false
+        message = 'Incidencias encontradas'
+        asunto.push({
+          listado69bInexistentes: data_block_lista_sat_69B_presuntos_inexistentes.inexistentes
+        })
+        logger.info(`${fileMethod} | Lista 69B response: ${JSON.stringify(data_block_lista_sat_69B_presuntos_inexistentes.inexistentes)}`)
       }
     }
 
@@ -4132,53 +4127,41 @@ const validacionBloc = async (req, res, next) => {
       const data_bloc_ofac = bloc_ofac
       if (Array.isArray(data_bloc_ofac.ofac) && data_bloc_ofac.ofac.length > 0) {
         sin_incidencias = false
-        message = 'RFC con problemas'
+        message = 'Incidencias encontradas'
         asunto.push({
           ofac: data_bloc_ofac.ofac
         })
         logger.info(`${fileMethod} | OFAC response: ${JSON.stringify(data_bloc_ofac.ofac)}`)
-
-        const ofac = data_bloc_ofac.ofac
-        for (let i of ofac) {
-          const guarda_bloc_ofac = await certificationService.guardaBloc_ofac(id_certification, i)
-          logger.info(`${fileMethod} | OFAC guardado: ${JSON.stringify(guarda_bloc_ofac)}`)
-        }
       }
     }
 
     if (bloc_concursos_mercantiles) {
       const data_concursos_mercantiles = bloc_concursos_mercantiles
-      if (Array.isArray(data_concursos_mercantiles.informe) && data_concursos_mercantiles.informe.length > 0) {
+      if (
+        Array.isArray(data_concursos_mercantiles.informe) &&
+        data_concursos_mercantiles.informe.length > 0
+      ) {
         sin_incidencias = false
-        message = 'RFC con problemas'
+        message = 'Incidencias encontradas'
         asunto.push({
           concursosMercantiles: data_concursos_mercantiles.informe
         })
         logger.info(`${fileMethod} | Concursos mercantiles response: ${JSON.stringify(data_concursos_mercantiles.informe)}`)
-
-        const concursosMercantiles = data_concursos_mercantiles.informe
-        for (let i of concursosMercantiles) {
-          const guarda_bloc_concursos_mercantiles = await certificationService.guardaBloc_concursos_mercantiles(id_certification, i)
-          logger.info(`${fileMethod} | Concursos mercantiles guardado: ${JSON.stringify(guarda_bloc_concursos_mercantiles)}`)
-        }
       }
     }
 
     if (bloc_proveedores_contratistas) {
       const data_proveedores_contratistas = bloc_proveedores_contratistas
-      if (Array.isArray(data_proveedores_contratistas.multados) && data_proveedores_contratistas.multados.length > 0) {
+      if (
+        Array.isArray(data_proveedores_contratistas.multados) &&
+        data_proveedores_contratistas.multados.length > 0
+      ) {
         sin_incidencias = false
-        message = 'RFC con problemas'
+        message = 'Incidencias encontradas'
         asunto.push({
           proveedores_contratistas: data_proveedores_contratistas.multados
         })
         logger.info(`${fileMethod} | proveedores_contratistas response: ${JSON.stringify(data_proveedores_contratistas.multados)}`)
-
-        const proveedoresContratistas = data_proveedores_contratistas.multados
-        for (let i of proveedoresContratistas) {
-          const guarda_bloc_proveedores_contratistas = await certificationService.guardaBloc_proveedores_contratistas(id_certification, i)
-          logger.info(`${fileMethod} | proveedores contratistas guardado: ${JSON.stringify(guarda_bloc_proveedores_contratistas.multados)}`)
-        }
       }
     }
 

--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -1040,8 +1040,8 @@ router.post('/generaReporteInformativoCredito', /*decryptMiddleware, authMiddlew
  *   post:
  *     tags:
  *       - Certificación
- *     summary: Realiza la validación de un bloque basado en nombre, apellido y RFC.
- *     description: Este endpoint permite validar la existencia de incidencias para un RFC, retornando la información relacionada.
+ *     summary: Realiza la validación de un bloque basado en nombre y apellido.
+ *     description: Este endpoint permite validar la existencia de incidencias retornando la información relacionada.
  *     requestBody:
  *       required: true
  *       content:
@@ -1057,10 +1057,6 @@ router.post('/generaReporteInformativoCredito', /*decryptMiddleware, authMiddlew
  *                 type: string
  *                 description: El apellido de la entidad o persona (opcional, puede estar vacío).
  *                 example: ""
- *               rfc:
- *                 type: string
- *                 description: "El RFC que se valida. Formato: 3 o 4 letras, 6 dígitos y 3 caracteres alfanuméricos."
- *                 example: "AAA100303L51"
  *     responses:
  *       200:
  *         description: Respuesta exitosa con el resultado de la validación.
@@ -1076,7 +1072,7 @@ router.post('/generaReporteInformativoCredito', /*decryptMiddleware, authMiddlew
  *                 message:
  *                   type: string
  *                   description: Mensaje de la respuesta.
- *                   example: "RFC con problemas"
+ *                   example: "Incidencias encontradas"
  *                 asunto:
  *                   type: array
  *                   items:
@@ -1096,7 +1092,7 @@ router.post('/generaReporteInformativoCredito', /*decryptMiddleware, authMiddlew
  *                               description: El nombre asociado a la incidencia.
  *                               example: "A& J EXPORTACIONES SADECV"
  *       400:
- *         description: Error de validación en el RFC o en los datos proporcionados.
+ *         description: Error de validación en los datos proporcionados.
  *         content:
  *           application/json:
  *             schema:

--- a/src/utils/schemas/certification.js
+++ b/src/utils/schemas/certification.js
@@ -58,8 +58,7 @@ const certificateMyCompanyForTest = Joi.object({
 
 const validacionBlocSchema = Joi.object({
   nombre: Joi.string().required(),
-  apellido: Joi.string().allow('').optional(),
-  rfc: Joi.string().pattern(/^([A-Za-z]{3,4}\d{6}[A-Za-z0-9]{3})$/).required()
+  apellido: Joi.string().allow('').optional()
 })
 
 module.exports = {


### PR DESCRIPTION
## Summary
- update validacionBloc schema to require only `nombre` and `apellido`
- update validacionBloc controller to work without RFC and remove DB writes
- update API docs to reflect new parameters
- adjust Postman collection example body

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c6d4a265c832d964a587dc1021c22