### PR TITLE
Fix payback calculation

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -2980,7 +2980,7 @@ const getScorePaybackFromSummary = async (
     if (utilidadOperativa.utilidad_operativa == 0) scoreOverride = 'N/A'
 
     const payback =
-      parseFloat(deudaCortoPlazo.deuda_corto_plazo) /
+      parseFloat(deudaCortoPlazo.otros_pasivos) /
       parseFloat(utilidadOperativa.utilidad_operativa)
 
     const paybackScore = parametrosAlgoritmo.paybackScore.find(p => {
@@ -2998,7 +2998,7 @@ const getScorePaybackFromSummary = async (
 
     return {
       score,
-      deuda_corto_plazo_periodo_anterior: deudaCortoPlazo.deuda_corto_plazo,
+      deuda_corto_plazo_periodo_anterior: deudaCortoPlazo.otros_pasivos,
       periodo_actual: deudaCortoPlazo.periodo_actual,
       periodo_anterior: deudaCortoPlazo.periodo_anterior,
       periodo_previo_anterior: deudaCortoPlazo.periodo_previo_anterior,

--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3836,6 +3836,7 @@ WHERE cer.certificacion_id = (
     const queryString = `
     SELECT
       deuda_corto_plazo,
+      otros_pasivos,
       tipo,
       periodo_actual,
       periodo_anterior,


### PR DESCRIPTION
## Summary
- compute Payback using `otros_pasivos`
- include the new field when retrieving short‑term debt

## Testing
- `npm test` *(fails: Missing script and npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c8efe98a0832dadb377ee40a62df8