### PR TITLE
Use stored total_pasivo_circulante for payback

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -3042,10 +3042,14 @@ const getScorePaybackFromSummary = async (
       estadoBalanceAnterior?.pasivo_diferido_anterior ?? 0
     )
     const pasivoCirculanteAnterior =
-      parseFloat(estadoBalanceAnterior?.proveedores_anterior ?? 0) +
-      parseFloat(estadoBalanceAnterior?.acreedores_anterior ?? 0) +
-      parseFloat(estadoBalanceAnterior?.inpuestos_x_pagar_anterior ?? 0) +
-      parseFloat(estadoBalanceAnterior?.otros_pasivos_anterior ?? 0)
+      calculoBalance?.total_pasivo_circulante_anterior != null
+        ? parseFloat(calculoBalance.total_pasivo_circulante_anterior)
+        : (
+            parseFloat(estadoBalanceAnterior?.proveedores_anterior ?? 0) +
+            parseFloat(estadoBalanceAnterior?.acreedores_anterior ?? 0) +
+            parseFloat(estadoBalanceAnterior?.inpuestos_x_pagar_anterior ?? 0) +
+            parseFloat(estadoBalanceAnterior?.otros_pasivos_anterior ?? 0)
+          )
 
     const totalPasivoLargoPlazo =
       pasivoLargoPlazoAnterior + pasivoDiferidoAnterior + pasivoCirculanteAnterior


### PR DESCRIPTION
## Summary
- use `total_pasivo_circulante_anterior` from `calculoBalance` when computing payback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685d86a8768c832da2b9e0924e1e3248