### PR TITLE
Fix missing alias in balance query

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -3237,6 +3237,7 @@ WHERE cer.certificacion_id = (
       cpe.acreedores as acreedores_${periodo},
       cpe.inpuestos_x_pagar as inpuestos_x_pagar_${periodo},
       cpe.otros_pasivos as otros_pasivos_${periodo},
+      cpe.total_pasivo_circulante as total_pasivo_circulante_${periodo},
       cpe.total_pasivo_largo_plazo as pasivo_largo_plazo_${periodo},
       cpe.pasivo_diferido as pasivo_diferido_${periodo},
       cpe.resultado_ejercicios_anteriores as resultado_ejercicios_anteriores_${periodo},


### PR DESCRIPTION
## Summary
- include `total_pasivo_circulante` column when retrieving balance data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d897bbd3c832d8efe3aeafb3f186e