### PR TITLE
Fix demandas placeholder substitution

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -18297,7 +18297,7 @@ const generarReporteCredito = async (customUuid, idEmpresa, id_reporte_credito, 
     strHTML_paso = strHTML_paso.replace('{_mercado_objetivo_importaciones_display_}', _mercado_objetivo_importaciones_display_);
     strHTML_paso = strHTML_paso.replace('{_mercado_objetivo_exportaciones_display_}', _mercado_objetivo_exportaciones_display_);
     //
-    strHTML_paso = strHTML_paso.replace('{_demandas_mensaje_}', mensaje);
+    strHTML_paso = strHTML_paso.replace(/{_demandas_mensaje_}/g, mensaje);
 
     const options = {
       format: "A4",


### PR DESCRIPTION
## Summary
- use global regex replacement for `{_demandas_mensaje_}` placeholder when generating certification HTML

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685dc2e2bd68832dadcc725cbde9f1fc