### PR TITLE
Fix apalancamiento formula row

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6243,17 +6243,13 @@ ${JSON.stringify(info_email_error, null, 2)}
               val.deuda_total_estado_balance_periodo_anterior
             )
             const capital = format(val.capital_contable_estado_balance)
-            const formulaResultado =
-              `Deuda total (periodo contable anterior): ${pasivo} / ` +
-              `Capital contable (periodo contable anterior): ${capital}`
+            const formulaResultado = val.operacion
+              ? val.operacion
+              : `Deuda total (periodo contable anterior): ${pasivo} / ` +
+                `Capital contable (periodo contable anterior): ${capital}`
             rows.push(
               `<tr><td>Fórmula del resultado</td><td>${formulaResultado}</td></tr>`
             )
-            if (val.operacion) {
-              rows.push(
-                `<tr><td>Operación</td><td>${val.operacion}</td></tr>`
-              )
-            }
           } else if (key === '_14_payback') {
             if (val.operacion) {
               rows.push(


### PR DESCRIPTION
## Summary
- show `operacion` value in the "Fórmula del resultado" row of the Apalancamiento score
- remove redundant operation row so the pdf table only displays one row for that data

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685de562418c832dba8b1b2e78ed50f4