### PR TITLE
Ensure V2 zero scores in pdf

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -62,6 +62,16 @@ const SCORE_KEYS = [
   '_16_referencias_comerciales'
 ]
 
+const V2_ZERO_KEYS = [
+  '_03_capital_contable',
+  '_08_ventas_anuales',
+  '_11_evolucion_ventas',
+  '_12_apalancamiento',
+  '_13_flujo_neto',
+  '_14_payback',
+  '_15_rotacion_ctas_x_cobrar'
+]
+
 let referenciasCatalogo = {}
 
 const loadReferenciasCatalogo = async () => {
@@ -5893,8 +5903,12 @@ ${JSON.stringify(info_email_error, null, 2)}
         _16_referencias_comerciales: 'referenciasProveedoresScore'
       }
 
+      const isV2 = Number(version_algoritmo) === 2
+
       const sumatoriaScores = SCORE_KEYS.reduce((acc, key) => {
-        const s = parseInt(rangos[key]?.score, 10)
+        let val = rangos[key]?.score
+        if (isV2 && V2_ZERO_KEYS.includes(key)) val = '0'
+        const s = parseInt(val, 10)
         if (!isNaN(s)) return acc + s
         const alt = parseInt(scores[scoreKeyMap[key]], 10)
         return isNaN(alt) ? acc : acc + alt
@@ -5922,6 +5936,9 @@ ${JSON.stringify(info_email_error, null, 2)}
       const sumatoriaScoreRows = SCORE_KEYS.map(key => {
         const label = scoreLabelMap[key] || key
         let value = rangos[key]?.score
+        if (isV2 && V2_ZERO_KEYS.includes(key)) {
+          value = '0'
+        }
         if (value === undefined || value === null || value === '') {
           value = scores[scoreKeyMap[key]] ?? '-'
         }


### PR DESCRIPTION
## Summary
- add `V2_ZERO_KEYS` list for algorithm v2
- force zero values in `sendEmailNodeMailer` when algorithm version is 2

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe702290832dbce7014c45719c35