### PR TITLE
Update algorithm v2 score explanation in PDF table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5942,7 +5942,9 @@ ${JSON.stringify(info_email_error, null, 2)}
           value = '-'
         }
         let descripcion = '-'
-        if (rangos[key] && typeof rangos[key] === 'object') {
+        if (Number(version_algoritmo) === 2 && Number(value) === 0) {
+          descripcion = 'Se ejecuta v2 de algoritmo el score por default es 0'
+        } else if (rangos[key] && typeof rangos[key] === 'object') {
           descripcion =
             rangos[key].descripcion ?? rangos[key].caso ?? rangos[key].tipo ?? '-'
         }


### PR DESCRIPTION
## Summary
- show explanation text when algorithm v2 assigns a default score of `0`

## Testing
- `npx standard src/controllers/api/certification.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e087d79f8832d99d3584424e6605d