### PR TITLE
Fix algorithm V2 validation when data is missing

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -5503,10 +5503,10 @@ ${JSON.stringify(info_email_error, null, 2)}
         isZero(balPrevio.saldo_inventarios)
 
       const resProvAcre =
-        isZero(balAnterior.proveedores) &&
-        isZero(balAnterior.acreedores) &&
-        isZero(balPrevio.proveedores) &&
-        isZero(balPrevio.acreedores)
+        (isMissing(balAnterior.proveedores) || isZero(balAnterior.proveedores)) &&
+        (isMissing(balAnterior.acreedores) || isZero(balAnterior.acreedores)) &&
+        (isMissing(balPrevio.proveedores) || isZero(balPrevio.proveedores)) &&
+        (isMissing(balPrevio.acreedores) || isZero(balPrevio.acreedores))
       const resVentas =
         isMissing(resAnterior.ventas_anuales) ||
         isMissing(resPrevio.ventas_anuales) ||


### PR DESCRIPTION
## Summary
- treat missing supplier and creditor values as zero when checking algorithm version 2

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ed8a37414832dbb18e01b89c50c95