### PR TITLE
Add PDF generation for credit evaluation

### DIFF
--- a/src/utils/pdfs/templates/credit-evaluation.ejs
+++ b/src/utils/pdfs/templates/credit-evaluation.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; color: #333; }
+    h1 { color:#0a3d8e; text-align:center; }
+    table { width:100%; border-collapse:collapse; margin-bottom:20px; font-size:12px; }
+    th, td { border:1px solid #ccc; padding:6px; }
+    th { background:#f0f0f0; }
+  </style>
+</head>
+<body>
+  <h1>Reporte de Crédito</h1>
+  <h2>Variables</h2>
+  <table>
+    <thead>
+      <tr><th>Variable</th><th>Valor</th></tr>
+    </thead>
+    <tbody>
+      <% for (const [nombre, val] of Object.entries(reporte.variables)) { %>
+        <tr><td><%= nombre %></td><td><%= val.valor_algoritmo %></td></tr>
+      <% } %>
+    </tbody>
+  </table>
+  <h2>Scores</h2>
+  <table>
+    <tbody>
+      <% for (const [nombre, val] of Object.entries(scores)) { %>
+        <tr><td><%= nombre %></td><td><%= val %></td></tr>
+      <% } %>
+    </tbody>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- include helper modules in `creditEvaluation.js`
- extend initial data to return `id_cliente` and `id_reporte_credito`
- add PDF generation and email sending in `guardarYEnviarReporte`
- store generated report using existing service
- create simple PDF template for credit evaluation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685eef70011c832d9bd6b97dbaa707a2