### PR TITLE
Fix undefined entry crash in certification rules

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -2640,7 +2640,9 @@ const getControlanteScoreFromSummary = async (
 
     const reglasConfiguradas =
       Array.isArray(parametrosAlgoritmo?.influenciaControlanteScore)
-        ? parametrosAlgoritmo.influenciaControlanteScore.map(r => r.nombre)
+        ? parametrosAlgoritmo.influenciaControlanteScore
+            .map(r => r.nombre)
+            .filter(Boolean)
         : []
 
     const reglaDesconocido = reglasConfiguradas.find(r =>


### PR DESCRIPTION
## Summary
- guard against undefined entries when building `reglasConfiguradas`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685f23d1adf0832d8379f8ff708f8db6