### PR TITLE
Fix sector riesgo scores table

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -6842,7 +6842,8 @@ ${JSON.stringify(info_email_error, null, 2)}
         'cat_evolucion_ventas_algoritmo',
         'cat_payback_algoritmo',
         'cat_rotacion_cuentas_cobrar_algoritmo',
-        'cat_incidencias_legales_algoritmo'
+        'cat_incidencias_legales_algoritmo',
+        'cat_sector_riesgo_sectorial_algoritmo'
       ]
 
       const referenceTables = variablesReference
@@ -6866,7 +6867,8 @@ ${JSON.stringify(info_email_error, null, 2)}
                 'cat_evolucion_ventas_algoritmo',
                 'cat_payback_algoritmo',
                 'cat_rotacion_cuentas_cobrar_algoritmo',
-                'cat_incidencias_legales_algoritmo'
+                'cat_incidencias_legales_algoritmo',
+                'cat_sector_riesgo_sectorial_algoritmo'
               ]
               const scoreColumn = singleScoreTables.includes(table)
                 ? `<td style="padding: 4px 6px; border: 1px solid #ccc;">${v1}</td>`


### PR DESCRIPTION
## Summary
- remove `Score V2` column on _2. Sector riesgo_ table
- rename its header to just **Score** by treating it as a single-score table

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f33066474832d9930abd33a657f77