### PR TITLE
Fix apalancamiento NaN parsing

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -2957,7 +2957,7 @@ const getScoreApalancamientoFromSummary = async (
 
     const parseNumber = require('../../utils/number')
 
-    const toFloat = (value) => parseNumber(value)
+    const toFloat = (value) => parseNumber(value ?? 0)
 
     const pasivoAnterior =
       toFloat(estadoBalanceAnterior?.pasivo_largo_plazo_anterior) +


### PR DESCRIPTION
## Summary
- avoid NaN in `getScoreApalancamientoFromSummary` by defaulting to zero when parsing numbers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f53bc6f24832dbd434b662c91f451