### PR TITLE
Fix locale parsing in apalancamiento

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -2957,7 +2957,7 @@ const getScoreApalancamientoFromSummary = async (
 
     const parseNumber = require('../../utils/number')
 
-    const toFloat = (value) => parseNumber(value)
+    const toFloat = (value) => parseNumber(value ?? 0)
 
     const pasivoAnterior =
       toFloat(estadoBalanceAnterior?.pasivo_largo_plazo_anterior) +

--- a/src/utils/number.js
+++ b/src/utils/number.js
@@ -1,9 +1,27 @@
 'use strict'
 
 const parseNumber = (val) => {
-  if (val === undefined || val === null) return NaN
-  const cleaned = String(val).replace(/[$,\s]/g, '')
-  return Number(cleaned)
+  if (val === undefined || val === null) return 0
+  if (typeof val === 'number') return Number.isNaN(val) ? 0 : val
+  let str = String(val).trim()
+  if (!str || str.toLowerCase() === 'null' || str.toLowerCase() === 'undefined') {
+    return 0
+  }
+  // remove currency symbols and spaces
+  str = str.replace(/[$\s]/g, '')
+  const lastComma = str.lastIndexOf(',')
+  const lastDot = str.lastIndexOf('.')
+  // Determine decimal separator by last occurrence
+  if (lastComma > lastDot) {
+    // comma is decimal separator, remove thousand dots
+    str = str.replace(/\./g, '')
+    str = str.replace(',', '.')
+  } else {
+    // dot is decimal separator (or no decimal part), remove thousand commas
+    str = str.replace(/,/g, '')
+  }
+  const num = Number(str)
+  return Number.isNaN(num) ? 0 : num
 }
 
 module.exports = parseNumber


### PR DESCRIPTION
## Summary
- improve `parseNumber` utility to treat empty strings and invalid values as zero

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f53bc6f24832dbd434b662c91f451