### PR TITLE
Fix undefined response handling in Konesh request

### DIFF
--- a/src/controllers/api/konesh.js
+++ b/src/controllers/api/konesh.js
@@ -519,6 +519,12 @@ const executeGenericKoneshRequest = async (rfc, razon_social, globalConfig, opts
   }
 
   const data = apiResponse.data
+  if (!data || !Array.isArray(data.transactionResponse01) || !data.transactionResponse01[0]) {
+    if (data && data.result === 'INVALID' && data.stage === 'AUTHENTICATION') {
+      apiResponse.errorMessage = data.message
+    }
+    return { apiResponse, result: null }
+  }
   const konesh_api_des = {
     transactionResponse01: [{
       data01: await descifra_konesh(data.transactionResponse01[0].data01),


### PR DESCRIPTION
## Summary
- prevent runtime exception when `transactionResponse01` data is missing
- detect authentication failure messages from Konesh

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f6074f5a4832dad132c4f880c0541