### PR TITLE
Add automatic Swagger docs generation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ const logger = require('../src/utils/logs/logger')
 const { startCronJobs } = require('./controllers/api/cron')
 const express = require('express')
 const swaggerUi = require('swagger-ui-express')
-const swaggerJsdoc = require('swagger-jsdoc')
+const generateOpenApi = require('./utils/generateOpenApi')
 const routes = require('./routes')// Aquí se importan las rutas desarrolladas en Arcsa, es decir, lo "nuevo" [apiRoutes] y las desarrolladas por la consultora [legacyRoutes]
 const helmet = require('helmet')
 const cors = require('cors')
@@ -19,27 +19,7 @@ const app = express()
 
 startCronJobs()
 
-// Configuración de Swagger
-const swaggerOptions = {
-  definition: {
-      openapi: '3.0.0',
-      info: {
-          title: 'Credibusiness',
-          version: '1.0.0',
-          description: 'Descripción de mi API',
-      },
-      servers: [
-          {
-              url: `http://localhost:${port || 3000}`,
-              description: 'Servidor local',
-          },
-      ],
-  },
-  apis: ['./src/routes/api/*.js'],
-};
-
-const swaggerDocs = swaggerJsdoc(swaggerOptions);
-
+const swaggerDocs = generateOpenApi(port)
 // Servir la documentación de Swagger en la ruta /api-docs
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 

--- a/src/routes/api_arcsa_v2/portal.js
+++ b/src/routes/api_arcsa_v2/portal.js
@@ -3,6 +3,27 @@
 const express = require('express');
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api_arcsa_v2/portal/nueva-ruta:
+ *   post:
+ *     summary: Ejemplo de ruta nueva
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *               content:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Respuesta exitosa
+ */
+
 router.post('/nueva-ruta', (req, res) => {
   const { title, content } = req.body;
   res.json({ success: true, message: 'nueva ruta a api', data: { title, content } });

--- a/src/utils/generateOpenApi.js
+++ b/src/utils/generateOpenApi.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+function collectRoutes(dir, prefix, paths) {
+  if (!fs.existsSync(dir)) return;
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.js'));
+  files.forEach(file => {
+    const content = fs.readFileSync(path.join(dir, file), 'utf8');
+    const fileName = file.replace(/\.js$/, '').replace(/\.ga$/, '');
+    const base = `${prefix}${fileName === 'index' ? '' : '/' + fileName}`;
+    const regex = /router\.(get|post|put|delete|patch)\s*\(\s*['"`]([^'"`]*)['"`]/g;
+    let match;
+    while ((match = regex.exec(content)) !== null) {
+      const method = match[1].toLowerCase();
+      const route = match[2];
+      const full = `${base}${route}`.replace(/\/\/+/, '/');
+      if (!paths[full]) paths[full] = {};
+      paths[full][method] = { responses: { 200: { description: 'Success' } } };
+    }
+  });
+}
+
+module.exports = function generateOpenApi(port) {
+  const paths = {};
+  collectRoutes(path.join(__dirname, '../routes/api'), '/api', paths);
+  collectRoutes(path.join(__dirname, '../routes/legacy'), '', paths);
+  collectRoutes(path.join(__dirname, '../routes/api_arcsa_v2'), '/api_arcsa_v2', paths);
+
+  return {
+    openapi: '3.0.0',
+    info: { title: 'Credibusiness', version: '1.0.0' },
+    servers: [
+      { url: `http://localhost:${port || 3000}`, description: 'Servidor local' }
+    ],
+    paths
+  };
+};


### PR DESCRIPTION
## Summary
- generate OpenAPI definition parsing route files
- serve generated docs using swagger-ui
- document API V2 portal route

## Testing
- `node -c src/app.js`
- `node - <<'NODE'
const gen = require('./src/utils/generateOpenApi');
const doc = gen(3000);
console.log(Object.keys(doc.paths).slice(0,5));
NODE`
- `npm install express-oas-generator --save` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_6862c559fe54832db32e19030e36ea9e