### PR TITLE
Update ventas anuales scoring

### DIFF
--- a/src/services/algorithm.js
+++ b/src/services/algorithm.js
@@ -99,6 +99,9 @@ class AlgorithmService {
         } else {
           entry.v2 = r.valor_algoritmo
         }
+        if (Object.prototype.hasOwnProperty.call(r, 'use_v2')) {
+          entry.use_v2 = Boolean(r.use_v2)
+        }
         if (Object.prototype.hasOwnProperty.call(r, 'limite_inferior')) {
           entry.limite_inferior = r.limite_inferior
         }


### PR DESCRIPTION
## Summary
- include `use_v2` field when loading algorithm ranges
- add handling of unknown annual sales for algorithm v2

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686447a4406c832da0309427988ccf3e