### PR TITLE
Add algorithm parameters PDF endpoint

### DIFF
--- a/src/controllers/api/algorithm.js
+++ b/src/controllers/api/algorithm.js
@@ -88,6 +88,31 @@ const getAlgorithmSummaryPdf = async (req, res, next) => {
   }
 }
 
+const getParametrosAlgoritmoPdf = async (req, res, next) => {
+  const fileMethod = 'file: src/controllers/api/algorithm.js - method: getParametrosAlgoritmoPdf'
+  try {
+    const parametrosAlgoritmo = await algorithmService.getGeneralSummary()
+
+    const templatePath = path.join(__dirname, '../../utils/pdfs/templates/algorithm-summary.ejs')
+    const html = await ejs.renderFile(templatePath, { resumenValores: parametrosAlgoritmo })
+
+    const options = {
+      format: 'A4',
+      printBackground: true,
+      margin: { top: 10, right: 10, bottom: 10, left: 10 }
+    }
+
+    const pdfBuffer = await html_to_pdf.generatePdf({ content: html }, options)
+
+    res.setHeader('Content-Type', 'application/pdf')
+    res.setHeader('Content-Disposition', 'attachment; filename=parametros-algoritmo.pdf')
+    return res.send(pdfBuffer)
+  } catch (error) {
+    logger.error(`${fileMethod} | ${error.message}`)
+    next(error)
+  }
+}
+
 const updateAlgorithmRanges = async (req, res, next) => {
   const fileMethod = 'file: src/controllers/api/algorithm.js - method: updateAlgorithmRanges'
   try {
@@ -108,5 +133,6 @@ module.exports = {
   getAlgorithmResult,
   getAlgorithmSummary,
   getAlgorithmSummaryPdf,
+  getParametrosAlgoritmoPdf,
   updateAlgorithmRanges
 }

--- a/src/routes/api/algorithm.js
+++ b/src/routes/api/algorithm.js
@@ -29,5 +29,16 @@ router.get('/summary', algorithmController.getAlgorithmSummary)
  */
 router.get('/summary/pdf', algorithmController.getAlgorithmSummaryPdf)
 
+/**
+ * @swagger
+ * /api/algorithm/parametros/pdf:
+ *   get:
+ *     summary: Genera un PDF con los parámetros del algoritmo
+ *     responses:
+ *       200:
+ *         description: PDF generado
+ */
+router.get('/parametros/pdf', algorithmController.getParametrosAlgoritmoPdf)
+
 router.put('/ranges', algorithmController.updateAlgorithmRanges)
 module.exports = router


### PR DESCRIPTION
## Summary
- create controller function to generate PDF of algorithm parameters
- expose the PDF endpoint at `/api/algorithm/parametros/pdf`

## Testing
- `npm test` *(fails: Missing script)*
- `npx standard` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_686457371644832d8d7fb7bb5de341ed