### PR TITLE
Fix PDF output for algorithm parameters

### DIFF
--- a/src/services/algorithm.js
+++ b/src/services/algorithm.js
@@ -94,11 +94,13 @@ class AlgorithmService {
         if (idField) {
           entry.id = r[idField]
         }
-        if (Object.prototype.hasOwnProperty.call(r, 'valor_algoritmo_v2')) {
+        const hasV2 = Object.prototype.hasOwnProperty.call(r, 'valor_algoritmo_v2')
+        if (hasV2) {
           entry.v2 = r.valor_algoritmo_v2
         } else {
           entry.v2 = r.valor_algoritmo
         }
+        entry.has_v2 = hasV2
         if (Object.prototype.hasOwnProperty.call(r, 'limite_inferior')) {
           entry.limite_inferior = r.limite_inferior
         }

--- a/src/utils/pdfs/templates/algorithm-summary.ejs
+++ b/src/utils/pdfs/templates/algorithm-summary.ejs
@@ -25,7 +25,9 @@
         <tr>
           <th>Nombre</th>
           <th>V1</th>
-          <th>V2</th>
+          <% if (filas[0].has_v2) { %>
+            <th>V2</th>
+          <% } %>
           <% if ('limite_inferior' in filas[0]) { %>
             <th>Límite inferior</th>
             <th>Límite superior</th>
@@ -40,7 +42,9 @@
           <tr>
             <td><%= row.nombre %></td>
             <td><%= row.v1 %></td>
-            <td><%= row.v2 %></td>
+            <% if (row.has_v2) { %>
+              <td><%= row.v2 %></td>
+            <% } %>
             <% if (row.limite_inferior !== undefined) { %>
               <td><%= row.limite_inferior %></td>
               <td><%= row.limite_superior %></td>


### PR DESCRIPTION
## Summary
- add `has_v2` flag to algorithm summary rows
- show V2 column in the algorithm summary PDF only when the table contains it

## Testing
- `npx standard --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6864592827fc832d897835b98047cc3e