### PR TITLE
Fix algorithm PDF page breaks

### DIFF
--- a/src/utils/pdfs/templates/algorithm-summary.ejs
+++ b/src/utils/pdfs/templates/algorithm-summary.ejs
@@ -6,8 +6,8 @@
     body { font-family: Arial, sans-serif; padding: 20px; color: #333; font-size:12px; }
     h1 { color:#0a3d8e; text-align:center; }
     h2 { background:#0a3d8e; color:#fff; padding:4px; font-size:13px; margin-top:20px; page-break-after: avoid; }
-    table { width:100%; border-collapse:collapse; margin-bottom:20px; font-size:11px; page-break-inside: avoid; break-inside: avoid; }
-    .table-section { page-break-inside: avoid; break-inside: avoid; }
+    table { width:100%; border-collapse:collapse; margin-bottom:20px; font-size:11px; }
+    .table-section { }
     th, td { border:1px solid #ccc; padding:6px; }
     th { background:#f0f0f0; }
   </style>


### PR DESCRIPTION
## Summary
- allow table sections in Algorithm PDF to break across pages

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68645c7f9730832d9eb19060b050d645