### PR TITLE
Fix PDF header when only v1 available

### DIFF
--- a/src/utils/pdfs/templates/algorithm-summary.ejs
+++ b/src/utils/pdfs/templates/algorithm-summary.ejs
@@ -25,9 +25,11 @@
       <thead>
         <tr>
           <th>Nombre</th>
-          <th>V1</th>
           <% if (filas[0].has_v2) { %>
+            <th>V1</th>
             <th>V2</th>
+          <% } else { %>
+            <th>Score</th>
           <% } %>
           <% if ('limite_inferior' in filas[0]) { %>
             <th>Límite inferior</th>


### PR DESCRIPTION
## Summary
- update algorithm PDF template header to display **Score** when there are no V2 values

## Testing
- `npx standard` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68655b14346c832d9e22b4a8763b268e