### PR TITLE
Replace console logs with logger in guardaReferenciasComerciales

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -1516,8 +1516,8 @@ const guardaReferenciasComerciales = async (req, res, next) => {
           //   await certificationService.updateContacto(referencia.contactos[i], referencia.contactos[i].id_certification_referencia_comercial);
           // }
           if (referencia.contactos[i].id_certification_referencia_comercial == 0) {
-            console.log('Este contacto no existe, se inserta en la referencia comercial')
-            console.log(referencia.contactos[i])
+            logger.info('Este contacto no existe, se inserta en la referencia comercial')
+            logger.info(JSON.stringify(referencia.contactos[i]))
             await certificationService.insertaContacto(referencia.contactos[i], 'enviado', referencia.id_certification_referencia_comercial)
           }
         }


### PR DESCRIPTION
## Summary
- replace `console.log` statements with `logger.info` in `guardaReferenciasComerciales`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867f94dbc1c832dae7f8ea5246fdd63