### PR TITLE
Add referencias_comerciales validation

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -1468,6 +1468,14 @@ const guardaReferenciasComerciales = async (req, res, next) => {
         boom.badRequest('El formato de referencias comerciales no es válido')
       )
     }
+    if (!referencias_comerciales.length) {
+      logger.warn(
+        `${fileMethod} | referencias_comerciales está vacío`
+      )
+      return next(
+        boom.badRequest('Se requieren referencias comerciales')
+      )
+    }
     let contactos = []
 
     const [empresa_origen] = await companiesService.getEmpresaById(id_empresa)

--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -879,6 +879,8 @@ router.post('/guardaMercadoObjetivo', /*decryptMiddleware, authMiddleware,*/ cer
  *                                   plazo:
  *                                     type: integer
  *                                     example: 30
+ *       '400':
+ *         description: "Se requieren referencias comerciales"
  */
 router.post('/guardaReferenciasComerciales', /*decryptMiddleware, authMiddleware,*/ certificationController.guardaReferenciasComerciales);
 


### PR DESCRIPTION
## Summary
- validate non-empty referencias_comerciales when saving
- document new validation in swagger for `guardaReferenciasComerciales`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867f94c8614832d9c1c5bba4c5c91e1