### PR TITLE
Add schema validation for commercial references

### DIFF
--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -7,7 +7,13 @@ const certificationController = require('../../controllers/api/certification')
 const multerGuardarPDF = require('../../utils/multerPdf')
 const authMiddleware = require('../../utils/middlewares/authMiddleware') 
 
-const { createCertification, payCertification, certificateMyCompanyForTest, validacionBlocSchema } = require('../../utils/schemas/certification')
+const {
+  createCertification,
+  payCertification,
+  certificateMyCompanyForTest,
+  validacionBlocSchema,
+  guardaReferenciasComercialesSchema
+} = require('../../utils/schemas/certification')
 const validation = require('../../utils/middlewares/validationHandler')
 const decryptMiddleware = require('../../utils/middlewares/cipherMiddleware')
 const creditEvaluationController = require('../../controllers/api/creditEvaluation')
@@ -880,7 +886,12 @@ router.post('/guardaMercadoObjetivo', /*decryptMiddleware, authMiddleware,*/ cer
  *                                     type: integer
  *                                     example: 30
  */
-router.post('/guardaReferenciasComerciales', /*decryptMiddleware, authMiddleware,*/ certificationController.guardaReferenciasComerciales);
+router.post(
+  '/guardaReferenciasComerciales',
+  /*decryptMiddleware, authMiddleware,*/
+  validation(guardaReferenciasComercialesSchema),
+  certificationController.guardaReferenciasComerciales
+);
 
 /**
  * @swagger

--- a/src/utils/schemas/certification.js
+++ b/src/utils/schemas/certification.js
@@ -61,9 +61,42 @@ const validacionBlocSchema = Joi.object({
   apellido: Joi.string().allow('').optional()
 })
 
+const guardaReferenciasComercialesSchema = Joi.object({
+  id_certification: Joi.number().required(),
+  id_empresa: Joi.number().required(),
+  referencias_comerciales: Joi.array()
+    .items(
+      Joi.object({
+        razon_social: Joi.string().required(),
+        denominacion: Joi.number().required(),
+        rfc: Joi.string().required(),
+        codigo_postal: Joi.string().required(),
+        id_pais: Joi.number().required(),
+        contactos: Joi.array()
+          .items(
+            Joi.object({
+              nombre_contacto: Joi.string().required(),
+              correo_contacto: Joi.string().email().required(),
+              telefono_contacto: Joi.string().required()
+            })
+          )
+          .required(),
+        empresa_cliente: Joi.object({
+          calificacion_referencia: Joi.string().required(),
+          porcentaje_deuda: Joi.number().required(),
+          dias_atraso: Joi.number().required(),
+          linea_credito: Joi.number().required(),
+          plazo: Joi.number().required()
+        }).required()
+      })
+    )
+    .required()
+})
+
 module.exports = {
   createCertification,
   payCertification,
   certificateMyCompanyForTest,
-  validacionBlocSchema
+  validacionBlocSchema,
+  guardaReferenciasComercialesSchema
 }


### PR DESCRIPTION
## Summary
- add `guardaReferenciasComercialesSchema` in certification schemas
- use the schema in `/guardaReferenciasComerciales` route to validate input

## Testing
- `npm test` *(fails: Missing script & no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6867f947f104832d8bde0765687c1b1d