### PR TITLE
Restore previous guardaReferenciasComerciales logic

### DIFF
--- a/src/controllers/api/certification.js
+++ b/src/controllers/api/certification.js
@@ -1435,7 +1435,7 @@ const guardaPartidasFinancieras = async (req, res, next) => {
       error: false,
       results: {
         created: true,
-        referenciasComerciales: body
+        partidasFinancieras: body
       }
     })}`)
 
@@ -1443,7 +1443,7 @@ const guardaPartidasFinancieras = async (req, res, next) => {
       error: false,
       results: {
         created: true,
-        referenciasComerciales: body
+        partidasFinancieras: body
       }
     })
 
@@ -1466,14 +1466,6 @@ const guardaReferenciasComerciales = async (req, res, next) => {
       )
       return next(
         boom.badRequest('El formato de referencias comerciales no es válido')
-      )
-    }
-    if (!referencias_comerciales.length) {
-      logger.warn(
-        `${fileMethod} | referencias_comerciales está vacío`
-      )
-      return next(
-        boom.badRequest('Se requieren referencias comerciales')
       )
     }
     let contactos = []
@@ -1524,8 +1516,8 @@ const guardaReferenciasComerciales = async (req, res, next) => {
           //   await certificationService.updateContacto(referencia.contactos[i], referencia.contactos[i].id_certification_referencia_comercial);
           // }
           if (referencia.contactos[i].id_certification_referencia_comercial == 0) {
-            logger.info('Este contacto no existe, se inserta en la referencia comercial')
-            logger.info(JSON.stringify(referencia.contactos[i]))
+            console.log('Este contacto no existe, se inserta en la referencia comercial')
+            console.log(referencia.contactos[i])
             await certificationService.insertaContacto(referencia.contactos[i], 'enviado', referencia.id_certification_referencia_comercial)
           }
         }
@@ -1601,7 +1593,7 @@ const guardaReferenciasComerciales = async (req, res, next) => {
       error: false,
       results: {
         created: true,
-        referenciasComerciales: body
+        partidasFinancieras: body
       }
     })}`)
 
@@ -1609,7 +1601,7 @@ const guardaReferenciasComerciales = async (req, res, next) => {
       error: false,
       results: {
         created: true,
-        referenciasComerciales: body
+        partidasFinancieras: body
       }
     })
   } catch (error) {

--- a/src/routes/api/certification.js
+++ b/src/routes/api/certification.js
@@ -11,8 +11,7 @@ const {
   createCertification,
   payCertification,
   certificateMyCompanyForTest,
-  validacionBlocSchema,
-  guardaReferenciasComercialesSchema
+  validacionBlocSchema
 } = require('../../utils/schemas/certification')
 const validation = require('../../utils/middlewares/validationHandler')
 const decryptMiddleware = require('../../utils/middlewares/cipherMiddleware')
@@ -823,7 +822,7 @@ router.post('/guardaMercadoObjetivo', /*decryptMiddleware, authMiddleware,*/ cer
  *                     created:
  *                       type: boolean
  *                       example: true
- *                     referenciasComerciales:
+ *                     partidasFinancieras:
  *                       type: object
  *                       properties:
  *                         id_certification:
@@ -885,15 +884,8 @@ router.post('/guardaMercadoObjetivo', /*decryptMiddleware, authMiddleware,*/ cer
  *                                   plazo:
  *                                     type: integer
  *                                     example: 30
- *       '400':
- *         description: "Se requieren referencias comerciales"
  */
-router.post(
-  '/guardaReferenciasComerciales',
-  /*decryptMiddleware, authMiddleware,*/
-  validation(guardaReferenciasComercialesSchema),
-  certificationController.guardaReferenciasComerciales
-);
+router.post('/guardaReferenciasComerciales', /*decryptMiddleware, authMiddleware,*/ certificationController.guardaReferenciasComerciales);
 
 /**
  * @swagger

--- a/src/utils/schemas/certification.js
+++ b/src/utils/schemas/certification.js
@@ -61,42 +61,9 @@ const validacionBlocSchema = Joi.object({
   apellido: Joi.string().allow('').optional()
 })
 
-const guardaReferenciasComercialesSchema = Joi.object({
-  id_certification: Joi.number().required(),
-  id_empresa: Joi.number().required(),
-  referencias_comerciales: Joi.array()
-    .items(
-      Joi.object({
-        razon_social: Joi.string().required(),
-        denominacion: Joi.number().required(),
-        rfc: Joi.string().required(),
-        codigo_postal: Joi.string().required(),
-        id_pais: Joi.number().required(),
-        contactos: Joi.array()
-          .items(
-            Joi.object({
-              nombre_contacto: Joi.string().required(),
-              correo_contacto: Joi.string().email().required(),
-              telefono_contacto: Joi.string().required()
-            })
-          )
-          .required(),
-        empresa_cliente: Joi.object({
-          calificacion_referencia: Joi.string().required(),
-          porcentaje_deuda: Joi.number().required(),
-          dias_atraso: Joi.number().required(),
-          linea_credito: Joi.number().required(),
-          plazo: Joi.number().required()
-        }).required()
-      })
-    )
-    .required()
-})
-
 module.exports = {
   createCertification,
   payCertification,
   certificateMyCompanyForTest,
-  validacionBlocSchema,
-  guardaReferenciasComercialesSchema
+  validacionBlocSchema
 }


### PR DESCRIPTION
## Summary
- revert guardaReferenciasComerciales validations and response field names
- remove schema for commercial references and associated validation
- update docs and route definition

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867fb09b380832d99f62d33ae80a404