### PR TITLE
Preserve answered references

### DIFF
--- a/src/services/certification.js
+++ b/src/services/certification.js
@@ -4260,6 +4260,29 @@ WHERE cer.certificacion_id = (
     return result;
   }
 
+  // Elimina únicamente las referencias comerciales no contestadas
+  async deleteReferenciasComercialesNoContestadas(idCertification) {
+    const queryString = `
+    DELETE FROM certification_referencia_comercial
+    WHERE id_certification = ${mysqlLib.escape(idCertification)}
+      AND (contestada <> 'si' OR contestada IS NULL);
+  `;
+    const result = await mysqlLib.query(queryString);
+    return result;
+  }
+
+  // Obtiene las referencias comerciales contestadas para una certificación
+  async getReferenciasComercialesContestadas(idCertification) {
+    const queryString = `
+    SELECT *
+      FROM certification_referencia_comercial
+     WHERE id_certification = ${mysqlLib.escape(idCertification)}
+       AND contestada = 'si';
+  `;
+    const { result } = await mysqlLib.query(queryString);
+    return result;
+  }
+
   async deleteDemandas(id_certification) {
     const queryString = `
     DELETE FROM certification_demandas


### PR DESCRIPTION
## Summary
- in `guardaReferenciasComerciales`, keep answered references
- add service helpers for fetching/deleting by answered status

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68682144d7ac832d9c997ff14f54d086