### PR TITLE
Fix parameter replacements for SQL queries

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -68,7 +68,7 @@ class MySequelize {
   }
 
   query (queryStr, params = []) {
-    const options = Array.isArray(params) && params.length > 0 ? { replacements: params } : undefined
+    const options = { replacements: Array.isArray(params) ? params : [] }
     return new Promise((resolve, reject) => {
       this.sequelize.query(queryStr, options)
         .then(res => {


### PR DESCRIPTION
## Summary
- ensure the db helper always passes an array of replacements to Sequelize

## Testing
- `node -v`
- `npx standard --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68683fafd7a8832d858a311eb7ce14a4